### PR TITLE
Fix duplicate adapter warning

### DIFF
--- a/packages/core/src/components/FormBuilder/StepFormCustomization/index.tsx
+++ b/packages/core/src/components/FormBuilder/StepFormCustomization/index.tsx
@@ -119,10 +119,10 @@ export function StepFormCustomization({
     );
   }
 
-  if (networkConfig && !adapter) {
+  if (!adapter) {
     return (
       <div className="py-8 text-center">
-        <p>Adapter not available for selected network. Please select a network.</p>
+        <p>Adapter not available. Please ensure network is selected and supported.</p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- remove unreachable adapter warning by consolidating message for missing adapter

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684412ac1da4832b9457e2f8eca9eac5