### PR TITLE
Fix adapter architecture link in core README

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -119,4 +119,4 @@ The core package uses an adapter pattern to support multiple blockchain ecosyste
 
 This architecture allows for easy extension to support additional blockchain ecosystems by creating new adapter packages and registering them in `ecosystemManager.ts`. The provider model (from `@openzeppelin/transaction-form-react-core`) ensures consistent state and adapter access throughout the application.
 
-For more detailed documentation about the adapter pattern, see the main project [README.md](../../README.md#adding-new-adapters) and the [Adapter Architecture Guide](../../docs/ADAPTER_ARCHITECTURE.MD).
+For more detailed documentation about the adapter pattern, see the main project [README.md](../../README.md#adding-new-adapters) and the [Adapter Architecture Guide](../../docs/ADAPTER_ARCHITECTURE.md).


### PR DESCRIPTION
## Summary
- fix the Adapter Architecture Guide link in `packages/core/README.md`

## Testing
- `pnpm -r test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684412a47b00832bb172385837eb8abe