### PR TITLE
fix(adapter-evm): Apply default speed configuration on initial mount

### DIFF
--- a/packages/adapter-evm/src/transaction/components/__tests__/useEvmRelayerOptions.test.ts
+++ b/packages/adapter-evm/src/transaction/components/__tests__/useEvmRelayerOptions.test.ts
@@ -1,0 +1,108 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Speed } from '@openzeppelin/relayer-sdk';
+
+import { useEvmRelayerOptions } from '../useEvmRelayerOptions';
+
+describe('useEvmRelayerOptions', () => {
+  let mockOnChange: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockOnChange = vi.fn();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('should notify parent with default speed on initial mount when no speed is provided', () => {
+    const options = {}; // No speed provided
+
+    renderHook(() =>
+      useEvmRelayerOptions({
+        options,
+        onChange: mockOnChange,
+      })
+    );
+
+    // Should be called once with the default speed
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith({ speed: Speed.FAST });
+  });
+
+  it('should not notify parent when speed is already provided in options', () => {
+    const options = { speed: Speed.AVERAGE }; // Speed already provided
+
+    renderHook(() =>
+      useEvmRelayerOptions({
+        options,
+        onChange: mockOnChange,
+      })
+    );
+
+    // Should not be called since speed is already provided
+    expect(mockOnChange).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not notify parent when custom gas settings are provided', () => {
+    const options = { gasPrice: 25000000000 }; // Custom gas price provided
+
+    renderHook(() =>
+      useEvmRelayerOptions({
+        options,
+        onChange: mockOnChange,
+      })
+    );
+
+    // Should not be called since custom settings are provided
+    expect(mockOnChange).toHaveBeenCalledTimes(0);
+  });
+
+  it('should include gasLimit in initial notification if provided', () => {
+    const options = { gasLimit: 500000 }; // Gas limit provided but no speed
+
+    renderHook(() =>
+      useEvmRelayerOptions({
+        options,
+        onChange: mockOnChange,
+      })
+    );
+
+    // Should be called with both speed and gasLimit
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith({
+      speed: Speed.FAST,
+      gasLimit: 500000,
+    });
+  });
+
+  it('should notify parent when speed is changed after initial mount', () => {
+    const options = {};
+
+    const { result } = renderHook(() =>
+      useEvmRelayerOptions({
+        options,
+        onChange: mockOnChange,
+      })
+    );
+
+    // Clear the initial call
+    mockOnChange.mockClear();
+
+    // Change speed
+    act(() => {
+      result.current.handleSpeedChange(Speed.FASTEST);
+    });
+
+    // Wait for the debounced update
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    // Should be called with the new speed
+    expect(mockOnChange).toHaveBeenCalledWith({ speed: Speed.FASTEST });
+  });
+});

--- a/packages/adapter-evm/src/transaction/components/useEvmRelayerOptions.ts
+++ b/packages/adapter-evm/src/transaction/components/useEvmRelayerOptions.ts
@@ -50,10 +50,26 @@ export const useEvmRelayerOptions = ({ options, onChange }: UseEvmRelayerOptions
   const isEip1559 = Boolean(formValues.maxFeePerGas || formValues.maxPriorityFeePerGas);
   const gasType = isEip1559 ? 'eip1559' : 'legacy';
 
-  // Notify parent of changes, but skip initial mount
+  // Handle initial mount - ensure the default speed value is communicated to parent
   useEffect(() => {
     if (isInitialMount.current) {
       isInitialMount.current = false;
+
+      // Only notify parent if we have a default speed value that wasn't already in options
+      if (initialOptions.speed && !options.speed) {
+        const newOptions: EvmRelayerTransactionOptions = {};
+        if (initialOptions.speed) newOptions.speed = initialOptions.speed;
+        if (initialOptions.gasLimit) newOptions.gasLimit = initialOptions.gasLimit;
+
+        onChange(newOptions as Record<string, unknown>);
+      }
+      return;
+    }
+  }, []);
+
+  // Notify parent of changes after initial mount
+  useEffect(() => {
+    if (isInitialMount.current) {
       return;
     }
 


### PR DESCRIPTION
## Problem

When users picked a relayer execution method in the form builder UI, the gas configuration showed "Fast Speed Preset Active" by default, but when the app was exported, the configuration contained  (20 gwei) instead of .

This was happening because the  hook was not communicating the initial default speed value to the parent component, causing the export to fall back to hardcoded gas values.

## Root Cause

The  in  was skipping the initial mount and never notifying the parent component of the default  value:

```typescript
useEffect(() => {
  if (isInitialMount.current) {
    isInitialMount.current = false;
    return; // ❌ This prevented parent notification on initial mount
  }
  // ... parent notification code
}, [formValues, onChange]);
```

## Solution

- Split the  into two separate effects:
  1. **Initial mount effect**: Communicates default speed value to parent if no speed is provided
  2. **Change tracking effect**: Handles subsequent form changes
- Ensures that when no gas configuration is provided, the default  is properly applied to the exported configuration
- Maintains backward compatibility with existing custom gas settings

## Testing

- Added comprehensive test coverage for  hook
- Tests verify default speed communication, edge cases, and subsequent changes
- All existing tests continue to pass

## Impact

- ✅ Exported apps now use intended speed presets instead of fallback gas values
- ✅ UI accurately reflects the actual exported configuration
- ✅ Maintains backward compatibility with custom gas settings
- ✅ No breaking changes to existing API

Fixes the discrepancy between UI display and exported configuration for gas settings.