### PR TITLE
Fix import paths for openzeppelin contracts ui builder

### DIFF
--- a/packages/builder/src/core/factories/FormSchemaFactory.ts
+++ b/packages/builder/src/core/factories/FormSchemaFactory.ts
@@ -16,7 +16,7 @@ import type {
   RenderFormSchema,
 } from '@openzeppelin/contracts-ui-builder-types';
 
-import { createTransformForFieldType } from '../../../../renderer/dist';
+import { createTransformForFieldType } from '@openzeppelin/contracts-ui-builder-renderer';
 import { generateFieldsFromFunction } from '../../services/FormGenerator';
 import { BuilderFormConfig } from '../types/FormTypes';
 import { humanizeString } from '../utils/utils';

--- a/packages/builder/src/export/PackageManager.ts
+++ b/packages/builder/src/export/PackageManager.ts
@@ -38,7 +38,7 @@ import { rendererConfig } from 'virtual:renderer-config';
 import { Ecosystem, UiKitConfiguration } from '@openzeppelin/contracts-ui-builder-types';
 import { logger } from '@openzeppelin/contracts-ui-builder-utils';
 
-import type { RendererConfig } from '../../../renderer/dist';
+import type { RendererConfig } from '@openzeppelin/contracts-ui-builder-renderer';
 import { adapterPackageMap } from '../core/ecosystemManager';
 import type { ExportOptions } from '../core/types/ExportTypes';
 import type { BuilderFormConfig } from '../core/types/FormTypes';


### PR DESCRIPTION
```
## Description
Replaced brittle relative import paths to `dist` directories with the proper `@openzeppelin/contracts-ui-builder-renderer` package name for `createTransformForFieldType` and `RendererConfig`.

## Related Issue
Fixes #

## Motivation and Context
The rebrand commit introduced incorrect import paths for `createTransformForFieldType` and `RendererConfig`, leading to inconsistent module resolution, development failures, and potential build problems. This change resolves these issues by ensuring imports correctly reference the published package, improving codebase robustness and maintainability.

## How Has This Been Tested?
This change primarily corrects import paths. Local build verification was performed to ensure the project compiles successfully with the updated paths. No specific runtime tests were executed as this is a build-time fix.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
```