### PR TITLE
Configure Etherscan API key to be included in docker build

### DIFF
--- a/.github/workflows/docker-prod.yaml
+++ b/.github/workflows/docker-prod.yaml
@@ -61,6 +61,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             VITE_EXPORT_ENV=production
+            VITE_APP_CFG_SERVICE_ETHERSCANV2_API_KEY=${{ secrets.VITE_APP_CFG_SERVICE_ETHERSCANV2_API_KEY }}
           secrets: |
             npm_token=${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/docker-stg.yaml
+++ b/.github/workflows/docker-stg.yaml
@@ -145,6 +145,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             VITE_EXPORT_ENV=staging
+            VITE_APP_CFG_SERVICE_ETHERSCANV2_API_KEY=${{ secrets.VITE_APP_CFG_SERVICE_ETHERSCANV2_API_KEY }}
           secrets: |
             npm_token=${{ secrets.NPM_TOKEN }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ ENV NODE_ENV=development
 ARG VITE_EXPORT_ENV=production
 ENV VITE_EXPORT_ENV=$VITE_EXPORT_ENV
 
+# Accept build argument for Etherscan V2 API key
+ARG VITE_APP_CFG_SERVICE_ETHERSCANV2_API_KEY
+ENV VITE_APP_CFG_SERVICE_ETHERSCANV2_API_KEY=$VITE_APP_CFG_SERVICE_ETHERSCANV2_API_KEY
+
 # Install build dependencies required for native Node.js modules
 # node-gyp (used by some dependencies) requires python and build-essential
 # 'python-is-python3' is used in newer Debian-based images instead of 'python'


### PR DESCRIPTION
%23%23 Description
Ensures the `VITE_APP_CFG_SERVICE_ETHERSCANV2_API_KEY` is correctly passed as a build argument during Docker image creation for both staging and production environments. This makes the key available to the Vite application at build time.

%23%23 Related Issue
<!--- Please link to the issue here: -->
Fixes %23

%23%23 Motivation and Context
The Buidler application relies on the `VITE_APP_CFG_SERVICE_ETHERSCANV2_API_KEY` for accessing block explorers. This key was not being provided during the Docker build process, preventing Etherscan API access in deployed environments. This change addresses the issue by injecting the key at build time, as required by Vite.

%23%23 How Has This Been Tested%3F
The changes involve updating CI/CD workflows and the Dockerfile to pass an environment variable.
- Verified that the `Dockerfile` now accepts `VITE_APP_CFG_SERVICE_ETHERSCANV2_API_KEY` as a build argument and sets it as an environment variable.
- Verified that `docker-stg.yaml` and `docker-prod.yaml` workflows pass the `VITE_APP_CFG_SERVICE_ETHERSCANV2_API_KEY` secret as a build argument to the Docker build process.

%23%23 Screenshots (if appropriate):
N/A

%23%23 Types of changes
<!--- What types of changes does your code introduce%3F Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

%23%23 Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents%3Fid=bc-9cd34f21-a942-4b82-8097-a02f9b69f798) · [Cursor](https://cursor.com/background-agent%3FbcId=bc-9cd34f21-a942-4b82-8097-a02f9b69f798)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)