### PR TITLE
chore: remove netlify deployment configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,6 @@ WORKDIR /builder
 RUN npm install -g serve
 
 # Copy the built application from the builder stage
-# This corresponds to the 'publish' directory in your previous netlify.toml
 COPY --from=builder /builder/packages/builder/dist ./dist
 
 # Expose the port the app will run on

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,0 @@
-[build]
-base = "/"
-command = "pnpm install-deps && pnpm build"
-publish = "packages/builder/dist"


### PR DESCRIPTION
Removed all Netlify-related configurations as the project no longer uses Netlify for deployment.

**Changes:**
- Delete `netlify.toml` configuration file
- Remove Netlify reference from Dockerfile comment

**Note:** `@netlify/blobs` references in `pnpm-lock.yaml` are harmless optional peer dependencies from the `unstorage` package and were left intact.