### PR TITLE
Feature/add mantra dukong evm testnet

### DIFF
--- a/packages/adapter-evm/package.json
+++ b/packages/adapter-evm/package.json
@@ -66,7 +66,7 @@
     "eslint": "^9.32.0",
     "jsdom": "^26.1.0",
     "typescript": "^5.9.2",
-    "viem": "^2.33.3",
+    "viem": "^2.35.1",
     "vitest": "^3.2.4",
     "wagmi": "^2.16.1"
   },
@@ -74,7 +74,7 @@
     "@rainbow-me/rainbowkit": "^2.2.8",
     "@tanstack/react-query": "^5.74.7",
     "react": "^19.0.0",
-    "viem": "^2.28.0",
+    "viem": "^2.35.1",
     "wagmi": "^2.15.0"
   },
   "exports": {

--- a/packages/adapter-evm/src/networks/index.ts
+++ b/packages/adapter-evm/src/networks/index.ts
@@ -19,6 +19,7 @@ import {
   bscTestnet,
   ethereumSepolia,
   lineaSepolia,
+  mantraDuKongEVMTestnet,
   monadTestnet,
   optimismSepolia,
   polygonAmoy,
@@ -57,6 +58,7 @@ export const evmTestnetNetworks: TypedEvmNetworkConfig[] = [
   scrollSepolia,
   zksyncSepoliaTestnet,
   monadTestnet,
+  mantraDuKongEVMTestnet,
   // Other testnet networks...
 ];
 
@@ -92,4 +94,5 @@ export {
   scrollSepolia,
   zksyncSepoliaTestnet,
   monadTestnet,
+  mantraDuKongEVMTestnet,
 };

--- a/packages/adapter-evm/src/networks/testnet.ts
+++ b/packages/adapter-evm/src/networks/testnet.ts
@@ -298,7 +298,7 @@ export const mantraDuKongEVMTestnet: TypedEvmNetworkConfig = {
   id: 'mantra-dukong-evm-testnet',
   exportConstName: 'mantraDuKongEVMTestnet',
   name: 'Mantra DuKong EVM Testnet',
-  ecosystem: 'cosmos',
+  ecosystem: 'evm',
   network: 'mantra-dukong',
   type: 'testnet',
   isTestnet: true,

--- a/packages/adapter-evm/src/networks/testnet.ts
+++ b/packages/adapter-evm/src/networks/testnet.ts
@@ -305,7 +305,7 @@ export const mantraDuKongEVMTestnet: TypedEvmNetworkConfig = {
   chainId: 5887,
   rpcUrl: viemMantraDuKongEVMTestnet.rpcUrls.default.http[0],
   explorerUrl: 'https://mantrascan.io/dukong',
-  // MANTRA Chain is not using Etherscan, so leaving this blank for now.
+  // MANTRA Chain is not using Etherscan, so leaving the following 2 fields empty.
   apiUrl: '',
   primaryExplorerApiIdentifier: '',
   supportsEtherscanV2: false,

--- a/packages/adapter-evm/src/networks/testnet.ts
+++ b/packages/adapter-evm/src/networks/testnet.ts
@@ -4,6 +4,7 @@ import {
   baseSepolia as viemBaseSepolia,
   bscTestnet as viemBscTestnet,
   lineaSepolia as viemLineaSepolia,
+  mantraDuKongEVMTestnet as viemMantraDuKongEVMTestnet,
   monadTestnet as viemMonadTestnet,
   optimismSepolia as viemOptimismSepolia,
   polygonAmoy as viemPolygonAmoy,
@@ -291,6 +292,30 @@ export const monadTestnet: TypedEvmNetworkConfig = {
     decimals: 18,
   },
   viemChain: viemMonadTestnet,
+};
+
+export const mantraDuKongEVMTestnet: TypedEvmNetworkConfig = {
+  id: 'mantra-dukong-evm-testnet',
+  exportConstName: 'mantraDuKongEVMTestnet',
+  name: 'Mantra DuKong EVM Testnet',
+  ecosystem: 'cosmos',
+  network: 'mantra-dukong',
+  type: 'testnet',
+  isTestnet: true,
+  chainId: 5887,
+  rpcUrl: viemMantraDuKongEVMTestnet.rpcUrls.default.http[0],
+  explorerUrl: 'https://mantrascan.io/dukong',
+  // MANTRA Chain is not using Etherscan, so leaving this blank for now.
+  apiUrl: '',
+  primaryExplorerApiIdentifier: '',
+  supportsEtherscanV2: false,
+  icon: 'mantra',
+  nativeCurrency: {
+    name: 'MANTRA',
+    symbol: 'OM',
+    decimals: 18,
+  },
+  viemChain: viemMantraDuKongEVMTestnet,
 };
 
 // TODO: Add other EVM testnet networks as needed (e.g., Arbitrum Sepolia)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR adds the MANTRA EVM testnet as a testnet option using the following config:
```typescript
export const mantraDuKongEVMTestnet: TypedEvmNetworkConfig = {
  id: 'mantra-dukong-evm-testnet',
  exportConstName: 'mantraDuKongEVMTestnet',
  name: 'Mantra DuKong EVM Testnet',
  ecosystem: 'evm',
  network: 'mantra-dukong',
  type: 'testnet',
  isTestnet: true,
  chainId: 5887,
  rpcUrl: viemMantraDuKongEVMTestnet.rpcUrls.default.http[0],
  explorerUrl: 'https://mantrascan.io/dukong',
  // MANTRA Chain is not using Etherscan, so leaving this blank for now.
  apiUrl: '',
  primaryExplorerApiIdentifier: '',
  supportsEtherscanV2: false,
  icon: 'mantra',
  nativeCurrency: {
    name: 'MANTRA',
    symbol: 'OM',
    decimals: 18,
  },
  viemChain: viemMantraDuKongEVMTestnet,
};
```

## Related Issue
<!--- Please link to the issue here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Run locally
2. Select Mantra DuKong EVM Testnet
3. Input contract address
4. Input ABI
5. Select function
6. Connect wallet and execute the function

## Screenshots:
<img width="2380" height="2358" alt="image" src="https://github.com/user-attachments/assets/d70c83ba-8e8b-430b-8fc4-b77778115883" />
<img width="3124" height="1840" alt="image" src="https://github.com/user-attachments/assets/18682891-1830-4725-be2d-71479fe1ee1a" />
<img width="5096" height="2000" alt="image" src="https://github.com/user-attachments/assets/c4c4eae8-10c6-4178-a530-3199cee72253" />
<img width="5080" height="2388" alt="image" src="https://github.com/user-attachments/assets/9095413a-56f5-45d2-be21-0aa005badb86" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. 