### PR TITLE
fix(export): link staging exports to new RC format

### DIFF
--- a/packages/builder/src/export/PackageManager.ts
+++ b/packages/builder/src/export/PackageManager.ts
@@ -437,12 +437,13 @@ export class PackageManager {
           updatedDependencies[pkgName] = 'workspace:*';
         } else if (env === 'staging') {
           // Staging: Use RC versions for testing latest features
-          // If managedVersion is already an RC version, use it as-is
-          // Otherwise, append -rc to create an RC version
+          // If managedVersion is already an RC version (e.g., 0.0.0-rc-20250915124300), use it
+          // Otherwise, fall back to using the 'rc' dist-tag so consumers pull the latest RC snapshot
           if (managedVersion.includes('-rc')) {
             updatedDependencies[pkgName] = managedVersion;
           } else {
-            updatedDependencies[pkgName] = `${managedVersion}-rc`;
+            // Using the dist-tag ensures alignment with snapshot format 0.0.0-rc-YYYYMMDDHHMMSS
+            updatedDependencies[pkgName] = 'rc';
           }
         } else {
           // Production: Use stable published versions

--- a/packages/builder/src/export/__tests__/PackageManager.test.ts
+++ b/packages/builder/src/export/__tests__/PackageManager.test.ts
@@ -322,22 +322,17 @@ describe('PackageManager', () => {
       );
       const result = JSON.parse(updated);
 
-      // Should append -rc to base versions for staging (version-agnostic approach)
-      // All OpenZeppelin internal packages should have -rc suffix
+      // Should use RC versions for staging: accept 'rc' tag or timestamped RC like 0.0.0-rc-YYYYMMDDHHMMSS
+      const rcVersionOrTag = /^(rc|\d+\.\d+\.\d+-rc(?:[-.]\d+)?)$/;
       expect(result.dependencies['@openzeppelin/contracts-ui-builder-renderer']).toMatch(
-        /^\d+\.\d+\.\d+-rc$/
+        rcVersionOrTag
       );
       expect(result.dependencies['@openzeppelin/contracts-ui-builder-types']).toMatch(
-        /^\d+\.\d+\.\d+-rc$/
+        rcVersionOrTag
       );
       expect(result.dependencies['@openzeppelin/contracts-ui-builder-adapter-evm']).toMatch(
-        /^\d+\.\d+\.\d+-rc$/
+        rcVersionOrTag
       );
-
-      // Verify all have -rc suffix (this approach works regardless of version numbers)
-      expect(result.dependencies['@openzeppelin/contracts-ui-builder-renderer']).toMatch(/-rc$/);
-      expect(result.dependencies['@openzeppelin/contracts-ui-builder-types']).toMatch(/-rc$/);
-      expect(result.dependencies['@openzeppelin/contracts-ui-builder-adapter-evm']).toMatch(/-rc$/);
 
       // Verify external deps don't get -rc treatment
       expect(result.dependencies['react']).not.toMatch(/-rc$/);
@@ -359,21 +354,17 @@ describe('PackageManager', () => {
       );
       const result = JSON.parse(updated);
 
-      // All internal packages should get -rc suffix (version-agnostic validation)
+      // All internal packages should resolve to RC format (either dist-tag 'rc' or timestamped RC)
+      const rcVersionOrTag = /^(rc|\d+\.\d+\.\d+-rc(?:[-.]\d+)?)$/;
       expect(result.dependencies['@openzeppelin/contracts-ui-builder-renderer']).toMatch(
-        /^\d+\.\d+\.\d+-rc$/
+        rcVersionOrTag
       );
       expect(result.dependencies['@openzeppelin/contracts-ui-builder-types']).toMatch(
-        /^\d+\.\d+\.\d+-rc$/
+        rcVersionOrTag
       );
       expect(result.dependencies['@openzeppelin/contracts-ui-builder-adapter-evm']).toMatch(
-        /^\d+\.\d+\.\d+-rc$/
+        rcVersionOrTag
       );
-
-      // Verify that staging environment produces RC versions
-      expect(result.dependencies['@openzeppelin/contracts-ui-builder-renderer']).toMatch(/-rc$/);
-      expect(result.dependencies['@openzeppelin/contracts-ui-builder-types']).toMatch(/-rc$/);
-      expect(result.dependencies['@openzeppelin/contracts-ui-builder-adapter-evm']).toMatch(/-rc$/);
     });
 
     it('should verify RC detection logic works correctly', async () => {
@@ -392,8 +383,9 @@ describe('PackageManager', () => {
       const stagingResult = JSON.parse(stagingUpdated);
 
       // All internal packages should have -rc suffix added (version-agnostic)
+      const rcVersionOrTag = /^(rc|\d+\.\d+\.\d+-rc(?:[-.]\d+)?)$/;
       expect(stagingResult.dependencies['@openzeppelin/contracts-ui-builder-renderer']).toMatch(
-        /^\d+\.\d+\.\d+-rc$/
+        rcVersionOrTag
       );
 
       // Test that production doesn't get -rc
@@ -458,7 +450,7 @@ describe('PackageManager', () => {
       );
       const stagingResult = JSON.parse(stagingUpdated);
       expect(stagingResult.dependencies['@openzeppelin/contracts-ui-builder-renderer']).toMatch(
-        /^\d+\.\d+\.\d+-rc$/
+        /^(rc|\d+\.\d+\.\d+-rc(?:[-.]\d+)?)$/
       );
 
       // Test production environment

--- a/packages/builder/src/export/__tests__/PackageManagerConfigLoading.test.ts
+++ b/packages/builder/src/export/__tests__/PackageManagerConfigLoading.test.ts
@@ -106,8 +106,8 @@ const createMinimalFormConfig = (fieldTypes: string[] = ['text']): BuilderFormCo
 });
 
 describe('PackageManager configuration loading', () => {
-  // Accept both plain "-rc" and timestamped RC variants like "-rc-20250813180014" or "-rc.123"
-  const rcVersionRegex = /-rc(?:[.-]\d+)?$/;
+  // Accept either the 'rc' dist-tag or timestamped RC variants like "0.0.0-rc-20250813180014"
+  const rcVersionOrTag = /^(rc|\d+\.\d+\.\d+-rc(?:[-.]\d+)?)$/;
   /**
    * This test suite focuses on testing the PackageManager with configurations
    * passed directly to the constructor, bypassing the dynamic loading mechanism.
@@ -184,12 +184,12 @@ describe('PackageManager configuration loading', () => {
         { env: 'staging' }
       );
       const result = JSON.parse(updated);
-      // Should use RC versions for staging (may include timestamp suffix)
+      // Should use RC versions for staging (either 'rc' dist-tag or timestamped RC)
       expect(result.dependencies['@openzeppelin/contracts-ui-builder-types']).toMatch(
-        rcVersionRegex
+        rcVersionOrTag
       );
       expect(result.dependencies['@openzeppelin/contracts-ui-builder-adapter-evm']).toMatch(
-        rcVersionRegex
+        rcVersionOrTag
       );
 
       // External dependencies should remain unchanged
@@ -220,7 +220,7 @@ describe('PackageManager configuration loading', () => {
         'workspace:*'
       );
       expect(stagingResult.dependencies['@openzeppelin/contracts-ui-builder-types']).toMatch(
-        rcVersionRegex
+        rcVersionOrTag
       );
       expect(prodResult.dependencies['@openzeppelin/contracts-ui-builder-types']).toMatch(/^\^/);
 


### PR DESCRIPTION
Fix: staging exports should link to new timestamped RCs

- Update staging versioning in `PackageManager.applyVersioningStrategy`:
  - If `managedVersion` already contains `-rc` (e.g., `0.0.0-rc-YYYYMMDDHHMMSS`), use it as-is.
  - Otherwise, use the `rc` dist-tag so staging exported apps resolve to the latest RC snapshot.
- Adjust tests to accept `rc` dist-tag or timestamped RC versions.
- Ran `pnpm run update-export-versions` and refreshed snapshots; all tests pass.

Why
- RC snapshots now publish as `0.0.0-rc-YYYYMMDDHHMMSS`. This ensures exported apps from staging either embed the exact RC from `versions.ts` or fall back to `rc` tag consistently.

Changes
- `packages/builder/src/export/PackageManager.ts`
- `packages/builder/src/export/__tests__/PackageManager.test.ts`
- `packages/builder/src/export/__tests__/PackageManagerConfigLoading.test.ts`

Checks
- [x] Unit tests pass
- [x] Snapshots updated
- [x] No adapter or type interface changes
