### PR TITLE
fix(ci): skip individual package builds during npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,6 +124,7 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
           TARBALL: ${{ needs.provenance.outputs.package-name }}
           NPM_CONFIG_ACCESS: public
+          SKIP_PUBLISH_BUILD: true
 
       - name: Extract version from package.json
         id: extract_version


### PR DESCRIPTION
## Description
The `adapter-evm` package was failing to publish due to TypeScript compilation errors when it couldn't resolve types from `react-core` during the parallel publishing process.

## Root Cause
During the changeset publish process, each package runs its `prepublishOnly` script which triggers individual builds. When packages are published in parallel, `adapter-evm` can't find the TypeScript declarations from `react-core` because:
1. The workspace protocol resolution doesn't work in the publish context
2. Dependencies may not be available yet due to parallel publishing

## Solution
Since the workflow already builds all packages before publishing (line 99-102), we can skip the individual `prepublishOnly` builds by setting `SKIP_PUBLISH_BUILD=true`. All packages are already configured to respect this environment variable in their `prepublishOnly` scripts.

## Changes
- Added `SKIP_PUBLISH_BUILD: true` to the environment variables in the publish workflow

## Benefits
- Prevents dependency resolution issues during parallel publishing
- Avoids redundant builds (packages are already built)
- Follows the same pattern already used in the staging workflow
- Fixes the immediate publishing issue

## Related Issue
Fixes the failing GitHub Actions workflow from run [#17953448505](https://github.com/OpenZeppelin/contracts-ui-builder/actions/runs/17953448505/job/51059161854)