### PR TITLE
fix(utils-logger): disable logs unless NODE_ENV is dev/test

### DIFF
--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -95,10 +95,10 @@ function getDefaultLoggerEnabled(): boolean {
     // Ignore environments where import.meta is not available or lacks env
   }
 
-  // Node/tsup: consider development as the only environment with default logging
+  // Node/tsup: enable logging only in explicit development or test environments
   if (typeof process !== 'undefined' && typeof process.env !== 'undefined') {
     const nodeEnv = process.env.NODE_ENV;
-    return nodeEnv === 'development' || nodeEnv === undefined;
+    return nodeEnv === 'development' || nodeEnv === 'test';
   }
 
   // Safe fallback: disabled


### PR DESCRIPTION
- Only enable logs in Vite dev or NODE_ENV=development/test
- Prevents accidental logging in prod/staging when NODE_ENV is unset

This adjusts  to return true only for dev/test.

Risk is low: tests and lints pass locally.\n
Follow-ups:
- Ensure staging/prod set NODE_ENV=production.\n- Optionally add env overrides: UI_BUILDER_LOG_ENABLED / UI_BUILDER_LOG_LEVEL.