### PR TITLE
fix(utils): disable logs when VITE_EXPORT_ENV is staging/production

### DIFF
--- a/.changeset/pink-planets-worry.md
+++ b/.changeset/pink-planets-worry.md
@@ -1,0 +1,6 @@
+---
+'@openzeppelin/ui-builder-utils': patch
+---
+
+Disable logs in staging/production by honoring VITE_EXPORT_ENV in logger defaults.
+Also keep logs enabled only for development/test.


### PR DESCRIPTION
- Force-disable logging in shared logger when VITE_EXPORT_ENV = staging or production (overrides Vite DEV)\n- Keeps logs enabled only in development/test\n- Adds changeset for @openzeppelin/ui-builder-utils (patch)\n\nThis should stop logs in both staging and production even if the app runs with a dev server or unusual Vite flags.