### PR TITLE
Fix BytesN handling in Stellar adapter

### DIFF
--- a/.changeset/stellar-bytesn-support.md
+++ b/.changeset/stellar-bytesn-support.md
@@ -1,0 +1,7 @@
+---
+'@openzeppelin/ui-builder-adapter-stellar': patch
+'@openzeppelin/ui-builder-types': patch
+---
+
+Fix BytesN parameter handling in Stellar forms so base64 inputs reuse the bytes field, propagate max byte hints, and convert to ScVal correctly.
+

--- a/packages/adapter-stellar/src/mapping/field-generator.ts
+++ b/packages/adapter-stellar/src/mapping/field-generator.ts
@@ -12,7 +12,7 @@ import type {
 import { getDefaultValueForType, logger } from '@openzeppelin/ui-builder-utils';
 
 import { extractMapTypes, extractVecElementType } from '../utils/safe-type-parser';
-import { isLikelyEnumType } from '../utils/type-detection';
+import { isBytesNType, isLikelyEnumType } from '../utils/type-detection';
 import { extractEnumVariants, isEnumType, type EnumMetadata } from './enum-metadata';
 import { mapStellarParameterTypeToFieldType } from './type-mapper';
 
@@ -91,6 +91,19 @@ export function generateStellarDefaultField<T extends FieldType = FieldType>(
     width: 'full',
     options,
   };
+
+  // Propagate max byte length for BytesN types so the UI can enforce it
+  if (isBytesNType(parameter.type)) {
+    const sizeMatch = parameter.type.match(/^BytesN<(\d+)>$/);
+    const maxBytes = sizeMatch ? Number.parseInt(sizeMatch[1], 10) : undefined;
+
+    if (!Number.isNaN(maxBytes) && Number.isFinite(maxBytes)) {
+      baseField.metadata = {
+        ...(baseField.metadata ?? {}),
+        maxBytes,
+      };
+    }
+  }
 
   // For array types, provide element type information
   if (fieldType === 'array') {

--- a/packages/adapter-stellar/src/mapping/type-mapper.ts
+++ b/packages/adapter-stellar/src/mapping/type-mapper.ts
@@ -1,6 +1,6 @@
 import type { FieldType } from '@openzeppelin/ui-builder-types';
 
-import { isLikelyEnumType } from '../utils/type-detection';
+import { isBytesNType, isLikelyEnumType } from '../utils/type-detection';
 import { STELLAR_TYPE_TO_FIELD_TYPE } from './constants';
 
 /**
@@ -48,8 +48,8 @@ export function mapStellarParameterTypeToFieldType(parameterType: string): Field
   }
 
   // Handle BytesN types (fixed-size byte arrays like BytesN<32> for hashes)
-  if (parameterType.startsWith('BytesN<')) {
-    return 'textarea'; // Users input as hex strings
+  if (isBytesNType(parameterType)) {
+    return 'bytes';
   }
 
   // Handle custom types (structs, enums) - default to object unless it's clearly an enum
@@ -101,6 +101,10 @@ export function getStellarCompatibleFieldTypes(parameterType: string): FieldType
       return ['array-object', 'textarea', 'text'];
     }
     return ['array', 'textarea', 'text'];
+  }
+
+  if (isBytesNType(parameterType)) {
+    return ['bytes', 'textarea', 'text'];
   }
 
   // Handle Vec types - allow array field or fallback to textarea/text

--- a/packages/adapter-stellar/src/utils/formatting.ts
+++ b/packages/adapter-stellar/src/utils/formatting.ts
@@ -114,6 +114,9 @@ export function convertStellarTypeToScValType(stellarType: string): string | str
     case 'DataUrl':
       return 'bytes';
     default:
+      if (/^BytesN<\d+>$/.test(stellarType)) {
+        return 'bytes';
+      }
       return stellarType.toLowerCase();
   }
 }

--- a/packages/adapter-stellar/src/utils/type-detection.ts
+++ b/packages/adapter-stellar/src/utils/type-detection.ts
@@ -157,3 +157,7 @@ export function isLikelyEnumType(parameterType: string): boolean {
 
   return enumPatterns.some((pattern) => pattern.test(parameterType));
 }
+
+export function isBytesNType(parameterType: string): boolean {
+  return /^BytesN<\d+>$/.test(parameterType);
+}

--- a/packages/adapter-stellar/test/mapping/field-generator.test.ts
+++ b/packages/adapter-stellar/test/mapping/field-generator.test.ts
@@ -6,6 +6,24 @@ import { generateStellarDefaultField } from '../../src/mapping/field-generator';
 
 describe('generateStellarDefaultField', () => {
   describe('basic field generation', () => {
+    it('should set maxBytes metadata for BytesN parameter', () => {
+      const parameter: FunctionParameter = {
+        name: 'signature',
+        type: 'BytesN<65>',
+        displayName: 'Signature',
+        description: 'Compressed signature',
+      };
+
+      const result = generateStellarDefaultField(parameter);
+
+      expect(result).toMatchObject({
+        name: 'signature',
+        label: 'Signature',
+        type: 'bytes',
+        metadata: { maxBytes: 65 },
+        validation: { required: true },
+      });
+    });
     it('should generate field for Address parameter', () => {
       const parameter: FunctionParameter = {
         name: 'user_address',
@@ -271,6 +289,28 @@ describe('generateStellarDefaultField', () => {
       const result = generateStellarDefaultField(parameter);
 
       expect(result.validation).toEqual({ required: true });
+    });
+
+    it('should generate field for BytesN parameter', () => {
+      const parameter: FunctionParameter = {
+        name: 'signature',
+        type: 'BytesN<65>',
+        displayName: 'Signature',
+        description: 'Compressed signature',
+      };
+
+      const result = generateStellarDefaultField(parameter);
+
+      expect(result).toMatchObject({
+        name: 'signature',
+        label: 'Signature',
+        type: 'bytes',
+        metadata: { maxBytes: 65 },
+        placeholder: 'Enter Signature',
+        helperText: 'Compressed signature',
+        validation: { required: true },
+        width: 'full',
+      });
     });
   });
 

--- a/packages/adapter-stellar/test/transform/input-parser.test.ts
+++ b/packages/adapter-stellar/test/transform/input-parser.test.ts
@@ -11,6 +11,15 @@ import {
 
 describe('parseStellarInput', () => {
   describe('primitive types', () => {
+    it('should parse BytesN values from base64', () => {
+      const base64Value =
+        'BHBgi1nbT7kAN+n2tiKV1CY4DiCM7FzECgIGz9YmB3lTMbbcA8xyq3mcW0QKKEtaW1tY6nzgfsPsHolWyNKkP5Q=';
+      const result = parseStellarInput(base64Value, 'BytesN<65>');
+
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect((result as Uint8Array).length).toBe(65);
+    });
+
     it('should parse boolean values', () => {
       expect(parseStellarInput(true, 'Bool')).toBe(true);
       expect(parseStellarInput(false, 'Bool')).toBe(false);

--- a/packages/types/src/forms/form-field.ts
+++ b/packages/types/src/forms/form-field.ts
@@ -37,6 +37,12 @@ export interface FormFieldType<T extends FieldType = FieldType> {
   helperText?: string;
 
   /**
+   * Additional information required to render or validate the field.
+   * Used for field-type-specific configuration (e.g., bytes length constraints).
+   */
+  metadata?: Record<string, unknown>;
+
+  /**
    * Default value for the field
    */
   defaultValue?: FieldValue<T>;


### PR DESCRIPTION
## Summary

- map Stellar `BytesN<N>` parameters to the shared `bytes` field so the existing `BytesField` handles formatting and validation
- surface `maxBytes` metadata for generated fields and decode BytesN values through the primitive parser before calling `nativeToScVal`
- update unit coverage to accept base64 BytesN inputs and align ScVal type hints with the laboratory implementation

Resolves #180

## Testing

- pnpm vitest run packages/adapter-stellar/test/mapping/field-generator.test.ts
- pnpm vitest run packages/adapter-stellar/test/transform/input-parser.test.ts

