### PR TITLE
Embed icon components in network configs to improve build performance

### DIFF
--- a/.changeset/embed-icon-components.md
+++ b/.changeset/embed-icon-components.md
@@ -1,0 +1,17 @@
+---
+"@openzeppelin/ui-builder-types": minor
+"@openzeppelin/ui-builder-adapter-evm": minor
+"@openzeppelin/ui-builder-adapter-stellar": minor
+"@openzeppelin/ui-builder-adapter-solana": minor
+"@openzeppelin/ui-builder-ui": minor
+"@openzeppelin/ui-builder-app": patch
+---
+
+Embed icon components in network configs; remove legacy icon string and dynamic icon usage.
+
+- Build performance: dramatically reduced build time and output file count
+- Runtime: no increase to runtime bundle size
+- API: `iconComponent` added to BaseNetworkConfig; `icon` string removed
+- Adapters: import specific `@web3icons/react` icons and set on configs
+- UI: prefer `network.iconComponent` when present
+

--- a/.changeset/fuzzy-laws-cover.md
+++ b/.changeset/fuzzy-laws-cover.md
@@ -1,0 +1,10 @@
+---
+'@openzeppelin/ui-builder-adapter-stellar': minor
+'@openzeppelin/ui-builder-adapter-solana': minor
+'@openzeppelin/ui-builder-adapter-evm': minor
+'@openzeppelin/ui-builder-app': minor
+'@openzeppelin/ui-builder-types': minor
+'@openzeppelin/ui-builder-ui': minor
+---
+
+Embed icon components in network configs; remove legacy icon string and dynamic icon usage. Improves build time and output file count; no runtime bundle size increase.

--- a/packages/adapter-evm/package.json
+++ b/packages/adapter-evm/package.json
@@ -54,6 +54,7 @@
     "@openzeppelin/relayer-sdk": "1.4.0",
     "@wagmi/connectors": "5.7.13",
     "@wagmi/core": "^2.20.3",
+    "@web3icons/react": "^4.0.19",
     "lodash": "^4.17.21",
     "lucide-react": "^0.510.0",
     "react-hook-form": "^7.62.0"

--- a/packages/adapter-evm/src/networks/mainnet.ts
+++ b/packages/adapter-evm/src/networks/mainnet.ts
@@ -1,4 +1,16 @@
 import {
+  NetworkArbitrumOne,
+  NetworkAvalanche,
+  NetworkBase,
+  NetworkBinanceSmartChain,
+  NetworkEthereum,
+  NetworkLinea,
+  NetworkOptimism,
+  NetworkPolygon,
+  NetworkScroll,
+  NetworkZksync,
+} from '@web3icons/react';
+import {
   arbitrum as viemArbitrum,
   avalanche as viemAvalanche,
   base as viemBase,
@@ -28,7 +40,7 @@ export const ethereumMainnet: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'ethereum',
+  iconComponent: NetworkEthereum,
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',
@@ -51,7 +63,7 @@ export const arbitrumMainnet: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'arbitrum',
+  iconComponent: NetworkArbitrumOne,
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',
@@ -74,7 +86,7 @@ export const polygonMainnet: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'polygon',
+  iconComponent: NetworkPolygon,
   nativeCurrency: {
     name: 'MATIC',
     symbol: 'MATIC',
@@ -97,7 +109,7 @@ export const polygonZkEvmMainnet: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'polygon',
+  iconComponent: NetworkPolygon,
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',
@@ -120,7 +132,7 @@ export const baseMainnet: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'base',
+  iconComponent: NetworkBase,
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',
@@ -143,7 +155,7 @@ export const bscMainnet: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'bsc',
+  iconComponent: NetworkBinanceSmartChain,
   nativeCurrency: {
     name: 'BNB',
     symbol: 'BNB',
@@ -166,7 +178,7 @@ export const optimismMainnet: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'optimism',
+  iconComponent: NetworkOptimism,
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',
@@ -189,7 +201,7 @@ export const avalancheMainnet: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'avalanche',
+  iconComponent: NetworkAvalanche,
   nativeCurrency: {
     name: 'Avalanche',
     symbol: 'AVAX',
@@ -213,7 +225,7 @@ export const zkSyncEraMainnet: TypedEvmNetworkConfig = {
   apiUrl: 'https://block-explorer-api.mainnet.zksync.io/api',
   primaryExplorerApiIdentifier: 'zksync-era-mainnet',
   supportsEtherscanV2: false,
-  icon: 'zksync',
+  iconComponent: NetworkZksync,
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',
@@ -236,7 +248,7 @@ export const scrollMainnet: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'scroll',
+  iconComponent: NetworkScroll,
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',
@@ -259,7 +271,7 @@ export const lineaMainnet: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'linea',
+  iconComponent: NetworkLinea,
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',

--- a/packages/adapter-evm/src/networks/testnet.ts
+++ b/packages/adapter-evm/src/networks/testnet.ts
@@ -1,4 +1,17 @@
 import {
+  NetworkArbitrumOne,
+  NetworkAvalanche,
+  NetworkBase,
+  NetworkBinanceSmartChain,
+  NetworkEthereum,
+  NetworkLinea,
+  NetworkMonad,
+  NetworkOptimism,
+  NetworkPolygon,
+  NetworkScroll,
+  NetworkZksync,
+} from '@web3icons/react';
+import {
   arbitrumSepolia as viemArbitrumSepolia,
   avalancheFuji as viemAvalancheFuji,
   baseSepolia as viemBaseSepolia,
@@ -29,7 +42,7 @@ export const ethereumSepolia: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'ethereum',
+  iconComponent: NetworkEthereum,
   nativeCurrency: {
     name: 'Sepolia Ether',
     symbol: 'ETH',
@@ -52,7 +65,7 @@ export const arbitrumSepolia: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'arbitrum',
+  iconComponent: NetworkArbitrumOne,
   nativeCurrency: {
     name: 'Arbitrum Sepolia Ether',
     symbol: 'ETH',
@@ -75,7 +88,7 @@ export const polygonAmoy: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'polygon',
+  iconComponent: NetworkPolygon,
   nativeCurrency: {
     name: 'MATIC',
     symbol: 'MATIC',
@@ -98,7 +111,7 @@ export const polygonZkEvmCardona: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'polygon',
+  iconComponent: NetworkPolygon,
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',
@@ -121,7 +134,7 @@ export const baseSepolia: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'base',
+  iconComponent: NetworkBase,
   nativeCurrency: {
     name: 'Sepolia Ether',
     symbol: 'ETH',
@@ -144,7 +157,7 @@ export const bscTestnet: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'bsc',
+  iconComponent: NetworkBinanceSmartChain,
   nativeCurrency: {
     name: 'BNB',
     symbol: 'BNB',
@@ -167,7 +180,7 @@ export const optimismSepolia: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'optimism',
+  iconComponent: NetworkOptimism,
   nativeCurrency: {
     name: 'Sepolia Ether',
     symbol: 'ETH',
@@ -191,7 +204,7 @@ export const avalancheFuji: TypedEvmNetworkConfig = {
   primaryExplorerApiIdentifier: 'etherscan-v2', // Unified identifier for V2 API
   supportsEtherscanV2: true,
   requiresExplorerApiKey: true,
-  icon: 'avalanche',
+  iconComponent: NetworkAvalanche,
   nativeCurrency: {
     name: 'Avalanche',
     symbol: 'AVAX',
@@ -215,7 +228,7 @@ export const zksyncSepoliaTestnet: TypedEvmNetworkConfig = {
   apiUrl: 'https://block-explorer-api.sepolia.zksync.dev/api',
   primaryExplorerApiIdentifier: 'zksync-era-sepolia',
   supportsEtherscanV2: false,
-  icon: 'zksync',
+  iconComponent: NetworkZksync,
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',
@@ -238,7 +251,7 @@ export const scrollSepolia: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'scroll',
+  iconComponent: NetworkScroll,
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',
@@ -261,7 +274,7 @@ export const lineaSepolia: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'linea',
+  iconComponent: NetworkLinea,
   nativeCurrency: {
     name: 'Linea Ether',
     symbol: 'ETH',
@@ -284,7 +297,7 @@ export const monadTestnet: TypedEvmNetworkConfig = {
   apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'etherscan-v2',
   supportsEtherscanV2: true,
-  icon: 'monad',
+  iconComponent: NetworkMonad,
   nativeCurrency: {
     name: 'Monad',
     symbol: 'MON',

--- a/packages/adapter-solana/src/networks/mainnet.ts
+++ b/packages/adapter-solana/src/networks/mainnet.ts
@@ -1,3 +1,5 @@
+import { NetworkSolana } from '@web3icons/react';
+
 import { SolanaNetworkConfig } from '@openzeppelin/ui-builder-types';
 
 // Placeholder for Solana Mainnet Beta
@@ -12,7 +14,7 @@ export const solanaMainnetBeta: SolanaNetworkConfig = {
   rpcEndpoint: 'https://api.mainnet-beta.solana.com',
   commitment: 'confirmed',
   explorerUrl: 'https://explorer.solana.com',
-  icon: 'solana',
+  iconComponent: NetworkSolana,
 };
 
 // Add other Solana mainnet networks if applicable

--- a/packages/adapter-solana/src/networks/testnet.ts
+++ b/packages/adapter-solana/src/networks/testnet.ts
@@ -1,3 +1,5 @@
+import { NetworkSolana } from '@web3icons/react';
+
 import { SolanaNetworkConfig } from '@openzeppelin/ui-builder-types';
 
 // Placeholder for Solana Devnet
@@ -12,7 +14,7 @@ export const solanaDevnet: SolanaNetworkConfig = {
   rpcEndpoint: 'https://api.devnet.solana.com',
   commitment: 'confirmed',
   explorerUrl: 'https://explorer.solana.com/?cluster=devnet',
-  icon: 'solana',
+  iconComponent: NetworkSolana,
 };
 
 // Placeholder for Solana Testnet
@@ -27,7 +29,7 @@ export const solanaTestnet: SolanaNetworkConfig = {
   rpcEndpoint: 'https://api.testnet.solana.com',
   commitment: 'confirmed',
   explorerUrl: 'https://explorer.solana.com/?cluster=testnet',
-  icon: 'solana',
+  iconComponent: NetworkSolana,
 };
 
 // Add other Solana testnet/devnet networks if applicable

--- a/packages/adapter-stellar/package.json
+++ b/packages/adapter-stellar/package.json
@@ -53,6 +53,7 @@
     "@openzeppelin/ui-builder-utils": "workspace:^",
     "@stellar/stellar-sdk": "^14.1.1",
     "@stellar/stellar-xdr-json": "^23.0.0",
+    "@web3icons/react": "^4.0.19",
     "lodash": "^4.17.21",
     "lossless-json": "^4.0.2",
     "lucide-react": "^0.510.0",

--- a/packages/adapter-stellar/src/networks/mainnet.ts
+++ b/packages/adapter-stellar/src/networks/mainnet.ts
@@ -1,3 +1,5 @@
+import { NetworkStellar } from '@web3icons/react';
+
 import { StellarNetworkConfig } from '@openzeppelin/ui-builder-types';
 
 // Stellar Public Network (Mainnet)
@@ -13,5 +15,5 @@ export const stellarPublic: StellarNetworkConfig = {
   sorobanRpcUrl: 'https://mainnet.sorobanrpc.com',
   networkPassphrase: 'Public Global Stellar Network ; September 2015',
   explorerUrl: 'https://stellar.expert/explorer/public',
-  icon: 'stellar',
+  iconComponent: NetworkStellar,
 };

--- a/packages/adapter-stellar/src/networks/testnet.ts
+++ b/packages/adapter-stellar/src/networks/testnet.ts
@@ -1,3 +1,5 @@
+import { NetworkStellar } from '@web3icons/react';
+
 import { StellarNetworkConfig } from '@openzeppelin/ui-builder-types';
 
 // Stellar Testnet
@@ -13,5 +15,5 @@ export const stellarTestnet: StellarNetworkConfig = {
   sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
   networkPassphrase: 'Test SDF Network ; September 2015',
   explorerUrl: 'https://stellar.expert/explorer/testnet',
-  icon: 'stellar',
+  iconComponent: NetworkStellar,
 };

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -56,7 +56,7 @@
     "@tanstack/react-query": "^5.84.1",
     "@types/jszip": "^3.4.1",
     "@uiw/react-textarea-code-editor": "^3.1.1",
-    "@web3icons/react": "^4.0.19",
+    "@web3icons/react": "^4.0.26",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "fast-equals": "^5.2.2",

--- a/packages/builder/src/components/UIBuilder/StepChainSelection/components/ChainSelector.tsx
+++ b/packages/builder/src/components/UIBuilder/StepChainSelection/components/ChainSelector.tsx
@@ -1,4 +1,4 @@
-import { NetworkIcon } from '@web3icons/react';
+import { NetworkEthereum, NetworkSolana, NetworkStellar } from '@web3icons/react';
 import { Clock } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -177,12 +177,33 @@ export function ChainSelector({
                         className={isDisabled ? 'opacity-50' : ''}
                       />
                     ) : option.network ? (
-                      <NetworkIcon
-                        name={option.network}
-                        size={24}
-                        variant="branded"
-                        className={isDisabled ? 'opacity-50' : ''}
-                      />
+                      option.network === 'ethereum' ? (
+                        <NetworkEthereum
+                          size={24}
+                          variant="branded"
+                          className={isDisabled ? 'opacity-50' : ''}
+                        />
+                      ) : option.network === 'stellar' ? (
+                        <NetworkStellar
+                          size={24}
+                          variant="branded"
+                          className={isDisabled ? 'opacity-50' : ''}
+                        />
+                      ) : option.network === 'solana' ? (
+                        <NetworkSolana
+                          size={24}
+                          variant="branded"
+                          className={isDisabled ? 'opacity-50' : ''}
+                        />
+                      ) : (
+                        <div
+                          className={`h-6 w-6 rounded-full bg-muted flex items-center justify-center ${isDisabled ? 'opacity-50' : ''}`}
+                        >
+                          <span className="text-xs font-medium text-muted-foreground">
+                            {option.label.charAt(0).toUpperCase()}
+                          </span>
+                        </div>
+                      )
                     ) : (
                       <div
                         className={`h-6 w-6 rounded-full bg-muted flex items-center justify-center ${isDisabled ? 'opacity-50' : ''}`}

--- a/packages/builder/src/components/UIBuilder/StepChainSelection/components/NetworkRow.tsx
+++ b/packages/builder/src/components/UIBuilder/StepChainSelection/components/NetworkRow.tsx
@@ -1,4 +1,3 @@
-import { NetworkIcon } from '@web3icons/react';
 import { Settings } from 'lucide-react';
 
 import type { NetworkConfig } from '@openzeppelin/ui-builder-types';
@@ -6,8 +5,9 @@ import { Button } from '@openzeppelin/ui-builder-ui';
 import { cn } from '@openzeppelin/ui-builder-utils';
 
 import MidnightLogoSvg from '../../../../assets/icons/MidnightLogo.svg';
-import { getNetworkIconName, ICON_SIZE } from '../utils/utils';
 import { NetworkDetail } from './NetworkDetail';
+
+const ICON_SIZE = 16;
 
 export interface NetworkRowProps {
   network: NetworkConfig;
@@ -17,7 +17,6 @@ export interface NetworkRowProps {
 }
 
 export function NetworkRow({ network, isSelected, onSelect, onOpenSettings }: NetworkRowProps) {
-  const iconName = getNetworkIconName(network);
   const isTestnetLike = network.type === 'testnet' || network.type === 'devnet';
 
   return (
@@ -51,13 +50,8 @@ export function NetworkRow({ network, isSelected, onSelect, onOpenSettings }: Ne
               height={ICON_SIZE}
               className="flex-shrink-0"
             />
-          ) : iconName ? (
-            <NetworkIcon
-              name={iconName}
-              size={ICON_SIZE}
-              variant="branded"
-              className="flex-shrink-0"
-            />
+          ) : network.iconComponent ? (
+            <network.iconComponent size={ICON_SIZE} variant="branded" className="flex-shrink-0" />
           ) : (
             <div className="bg-muted flex-shrink-0 h-4 w-4 rounded-full"></div>
           )}

--- a/packages/builder/src/components/UIBuilder/StepChainSelection/utils/utils.ts
+++ b/packages/builder/src/components/UIBuilder/StepChainSelection/utils/utils.ts
@@ -1,10 +1,1 @@
-import type { NetworkConfig } from '@openzeppelin/ui-builder-types';
-
 export const ICON_SIZE = 16;
-
-export function getNetworkIconName(network: NetworkConfig): string | null {
-  if (network.ecosystem === 'midnight') {
-    return null;
-  }
-  return network.icon || network.network.toLowerCase();
-}

--- a/packages/builder/src/core/factories/__tests__/EVMAdapterIntegration.test.ts
+++ b/packages/builder/src/core/factories/__tests__/EVMAdapterIntegration.test.ts
@@ -36,7 +36,6 @@ const mockEvmNetworkConfig: EvmNetworkConfig = {
   rpcUrl: 'http://localhost:8545', // Mock RPC URL
   nativeCurrency: { name: 'TestETH', symbol: 'TETH', decimals: 18 },
   apiUrl: 'https://api.etherscan.io/api', // Mock API URL, can be anything for tests not hitting network
-  icon: 'ethereum',
 };
 
 describe('EVM Adapter Integration Tests', () => {

--- a/packages/types/src/networks/config.ts
+++ b/packages/types/src/networks/config.ts
@@ -4,6 +4,8 @@
  * This file defines the TypeScript types for network configurations across different blockchain ecosystems.
  * It uses a discriminated union pattern with the 'ecosystem' property as the discriminant to ensure type safety.
  */
+import type React from 'react';
+
 import { Ecosystem, NetworkType } from '../common/ecosystem';
 
 /**
@@ -54,10 +56,16 @@ export interface BaseNetworkConfig {
   explorerUrl?: string;
 
   /**
-   * Optional icon name for the network (for use with @web3icons/react or similar)
-   * If not provided, the network property will be used as a fallback
+   * Optional React component for the network icon.
+   * This allows embedding the icon component directly in the network config,
+   * avoiding dynamic imports and improving build performance.
+   * If provided, this takes precedence over the icon string.
    */
-  icon?: string;
+  iconComponent?: React.ComponentType<{
+    size?: number;
+    className?: string;
+    variant?: 'mono' | 'branded';
+  }>;
 
   /**
    * A unique identifier for the specific explorer API service used by this network.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -65,7 +65,7 @@
     "@radix-ui/react-toast": "^1.2.14",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@uiw/react-textarea-code-editor": "^3.1.1",
-    "@web3icons/react": "^4.0.19",
+    "@web3icons/react": "^4.0.26",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lodash": "^4.17.21",

--- a/packages/ui/src/components/ui/network-status-badge.tsx
+++ b/packages/ui/src/components/ui/network-status-badge.tsx
@@ -1,4 +1,3 @@
-import { NetworkIcon } from '@web3icons/react';
 import React from 'react';
 
 import type { NetworkConfig } from '@openzeppelin/ui-builder-types';
@@ -14,14 +13,6 @@ interface NetworkStatusBadgeProps {
 // Define constants for consistency
 const ICON_SIZE = 16;
 
-function getNetworkIconName(network: NetworkConfig): string | null {
-  // TODO: submit a PR to web3icons to add midnight to the list of networks
-  if (network.ecosystem === 'midnight') {
-    return null;
-  }
-  return network.icon || network.network.toLowerCase();
-}
-
 /**
  * NetworkStatusBadge - Displays network information in a compact badge format
  * Shows the network icon, ecosystem, and name with dashed borders for testnet/devnet
@@ -32,7 +23,6 @@ export function NetworkStatusBadge({
 }: NetworkStatusBadgeProps): React.ReactElement | null {
   if (!network) return null;
 
-  const iconName = getNetworkIconName(network);
   const isTestnetLike = network.type === 'testnet' || network.type === 'devnet';
 
   return (
@@ -46,8 +36,8 @@ export function NetworkStatusBadge({
       {/* Network icon - reusing same icon component from NetworkRow */}
       {network.ecosystem === 'midnight' ? (
         <img src={MidnightLogoSvg} alt="Midnight" width={ICON_SIZE} height={ICON_SIZE} />
-      ) : iconName ? (
-        <NetworkIcon name={iconName} size={ICON_SIZE} variant="branded" />
+      ) : network.iconComponent ? (
+        <network.iconComponent size={ICON_SIZE} variant="branded" />
       ) : (
         <div className="bg-muted-foreground/20 flex-shrink-0 h-4 w-4 rounded-full"></div>
       )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       '@wagmi/core':
         specifier: ^2.20.3
         version: 2.20.3(@tanstack/query-core@5.87.4)(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@web3icons/react':
+        specifier: ^4.0.19
+        version: 4.0.26(react@19.1.1)(typescript@5.9.2)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -296,6 +299,9 @@ importers:
       '@stellar/stellar-xdr-json':
         specifier: ^23.0.0
         version: 23.0.0
+      '@web3icons/react':
+        specifier: ^4.0.19
+        version: 4.0.26(react@19.1.1)(typescript@5.9.2)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -412,8 +418,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1(@babel/runtime@7.28.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@web3icons/react':
-        specifier: ^4.0.19
-        version: 4.0.24(react@19.1.1)(typescript@5.9.2)
+        specifier: ^4.0.26
+        version: 4.0.26(react@19.1.1)(typescript@5.9.2)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -823,8 +829,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1(@babel/runtime@7.28.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@web3icons/react':
-        specifier: ^4.0.19
-        version: 4.0.24(react@19.1.1)(typescript@5.9.2)
+        specifier: ^4.0.26
+        version: 4.0.26(react@19.1.1)(typescript@5.9.2)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -4396,13 +4402,13 @@ packages:
   '@walletconnect/window-metadata@1.0.1':
     resolution: {integrity: sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==}
 
-  '@web3icons/common@0.11.18':
-    resolution: {integrity: sha512-YLw35hkWn07SP/yY/yR0C7lNAWsPk0I72i6l+Gu+fjm9ANyteaWShT0sPgWgNgECWma49McNqqq95q5T6SCB+w==}
+  '@web3icons/common@0.11.20':
+    resolution: {integrity: sha512-MTWgyHg6qzq9NfUcLnRvKqI5zNbEWUYjDTQmfDncJGXFruQrVGOyE+qDvj95Kq6+VJCfKyUBkQhQ9LUMmCK3pA==}
     peerDependencies:
       typescript: ^5.0.0
 
-  '@web3icons/react@4.0.24':
-    resolution: {integrity: sha512-zZ5zDrRKJZRICJCmHw4rjo04kpDIaziR7EuqeVuWXJTMSb4lP9W5o5kTo5MTyAlX7XOxk9pKGb6I0Smmcy1SGg==}
+  '@web3icons/react@4.0.26':
+    resolution: {integrity: sha512-Xu/PrV5IxRk/Emqn8JsooaU8Aeq56r74kO0pPMJBvVCDUs7OIcQyhKQONeD/RJfZbyUEbKyv6aHFefM+7/OGaw==}
     peerDependencies:
       react: ^18.2.0
 
@@ -15106,13 +15112,13 @@ snapshots:
       '@walletconnect/window-getters': 1.0.1
       tslib: 1.14.1
 
-  '@web3icons/common@0.11.18(typescript@5.9.2)':
+  '@web3icons/common@0.11.20(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
 
-  '@web3icons/react@4.0.24(react@19.1.1)(typescript@5.9.2)':
+  '@web3icons/react@4.0.26(react@19.1.1)(typescript@5.9.2)':
     dependencies:
-      '@web3icons/common': 0.11.18(typescript@5.9.2)
+      '@web3icons/common': 0.11.20(typescript@5.9.2)
       react: 19.1.1
     transitivePeerDependencies:
       - typescript


### PR DESCRIPTION
Changes:\n- Add iconComponent to BaseNetworkConfig and remove legacy icon string\n- Update EVM/Stellar/Solana adapters to statically import @web3icons/react icons\n- Update UI to prefer network.iconComponent; remove LimitedNetworkIcon and registries\n- Add changesets for affected packages