### PR TITLE
docs(common): add pnpm build to getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,13 +294,19 @@ For more details, see the [Midnight Adapter README](./packages/adapter-midnight/
    pnpm install
    ```
 
-3. Start the development server:
+3. Build all packages:
+
+   ```bash
+   pnpm build
+   ```
+
+4. Start the development server:
 
    ```bash
    pnpm dev
    ```
 
-4. Open your browser and navigate to `http://localhost:5173`
+5. Open your browser and navigate to `http://localhost:5173`
 
 ### Running with Docker (Recommended)
 


### PR DESCRIPTION
Add pnpm build to getting started steps in readme.

The packages need to be built before running pnpm dev, otherwise it fails.