### PR TITLE
fix(ci): correct package name in changeset from ui-builder-builder to ui-builder-app

### DIFF
--- a/.changeset/runtime-secret-feature.md
+++ b/.changeset/runtime-secret-feature.md
@@ -1,7 +1,7 @@
 ---
 '@openzeppelin/ui-builder-types': minor
 '@openzeppelin/ui-builder-ui': minor
-'@openzeppelin/ui-builder-builder': minor
+'@openzeppelin/ui-builder-app': minor
 '@openzeppelin/ui-builder-renderer': minor
 '@openzeppelin/ui-builder-adapter-midnight': minor
 ---


### PR DESCRIPTION
## Problem
The `publish-rc` action was failing with the following error:
```
Error: Found changeset runtime-secret-feature for package @openzeppelin/ui-builder-builder which is not in the workspace
```

## Solution
Fixed the incorrect package name in `.changeset/runtime-secret-feature.md`:
- Changed from: `@openzeppelin/ui-builder-builder`
- Changed to: `@openzeppelin/ui-builder-app`

## Changes
- Updated `.changeset/runtime-secret-feature.md` to use the correct package name

This fix will allow the `pnpm changeset version --snapshot rc` command to run successfully in CI/CD.