### PR TITLE
fix(builder): resolve TypeScript typecheck errors

### DIFF
--- a/packages/builder/src/components/UIBuilder/StepContractDefinition/__tests__/deepLinkDedupe.test.tsx
+++ b/packages/builder/src/components/UIBuilder/StepContractDefinition/__tests__/deepLinkDedupe.test.tsx
@@ -101,6 +101,8 @@ describe('Deep link auto-load deduplication', () => {
         proxyInfo: null,
         error: null,
         contractDefinitionArtifacts: null,
+        requiredInputSnapshot: null,
+        requiresManualReload: false,
       },
       needsContractDefinitionLoad: true,
     });

--- a/packages/builder/src/components/UIBuilder/StepContractDefinition/__tests__/manualAbiLoad.test.tsx
+++ b/packages/builder/src/components/UIBuilder/StepContractDefinition/__tests__/manualAbiLoad.test.tsx
@@ -131,6 +131,8 @@ describe('Manual ABI loading deduplication', () => {
         proxyInfo: null,
         error: null,
         contractDefinitionArtifacts: null,
+        requiredInputSnapshot: null,
+        requiresManualReload: false,
       },
       needsContractDefinitionLoad: true,
     });

--- a/packages/builder/src/components/UIBuilder/index.tsx
+++ b/packages/builder/src/components/UIBuilder/index.tsx
@@ -217,7 +217,7 @@ export function UIBuilder() {
           networkConfig={state.selectedNetwork}
           onToggleContractState={widget.toggle}
           isWidgetExpanded={state.isWidgetVisible}
-          adapter={state.selectedAdapter}
+          adapter={state.selectedAdapter ?? undefined}
         />
       ),
       isValid: !!state.selectedFunction,

--- a/packages/builder/src/core/factories/__tests__/FormSchemaFactory.test.ts
+++ b/packages/builder/src/core/factories/__tests__/FormSchemaFactory.test.ts
@@ -87,6 +87,7 @@ const mockAdapterInstance: ContractAdapter = {
   getContractDefinitionInputs: vi.fn(() => []),
   getRelayers: vi.fn().mockResolvedValue([]),
   getRelayer: vi.fn().mockResolvedValue({} as RelayerDetailsRich),
+  getNetworkServiceForms: vi.fn(() => []),
 };
 
 describe('FormSchemaFactory', () => {


### PR DESCRIPTION
## Problem
The TypeScript typecheck was failing with 4 errors:
1. Type mismatch: `ContractAdapter | null` not assignable to `ContractAdapter | undefined` in UIBuilder component
2. Missing `requiredInputSnapshot` and `requiresManualReload` properties in ContractState test fixtures
3. Missing `getNetworkServiceForms` method in mock adapter for FormSchemaFactory test

## Solution
- Fixed adapter prop type mismatch by converting `null` to `undefined` using nullish coalescing operator
- Added missing ContractState properties (`requiredInputSnapshot: null`, `requiresManualReload: false`) to test files
- Added missing `getNetworkServiceForms` method to mock adapter instance

## Changes
- `packages/builder/src/components/UIBuilder/index.tsx`: Fixed adapter prop type
- `packages/builder/src/components/UIBuilder/StepContractDefinition/__tests__/deepLinkDedupe.test.tsx`: Added missing ContractState properties
- `packages/builder/src/components/UIBuilder/StepContractDefinition/__tests__/manualAbiLoad.test.tsx`: Added missing ContractState properties
- `packages/builder/src/core/factories/__tests__/FormSchemaFactory.test.ts`: Added missing method to mock adapter

## Verification
✅ All TypeScript typecheck errors resolved
✅ `pnpm -r typecheck` passes successfully