### PR TITLE
fix(adapter-stellar,react-core): fix UI kit switching and Execute Transaction button

### DIFF
--- a/.changeset/fix-stellar-ui-kit-wallet-connection.md
+++ b/.changeset/fix-stellar-ui-kit-wallet-connection.md
@@ -1,0 +1,11 @@
+---
+'@openzeppelin/ui-builder-adapter-stellar': patch
+'@openzeppelin/ui-builder-react-core': patch
+---
+
+Fix Stellar UI kit wallet connection and Execute Transaction button issues
+
+- Fix WalletConnectionUI to recompute wallet components on each render, ensuring UI kit changes are reflected immediately when toggling between "Stellar Wallets Kit Custom" and "Stellar Wallets Kit"
+- Fix StellarWalletsKitConnectButton to propagate connection state changes to adapter's wallet implementation, ensuring Execute Transaction button enables when wallet is connected
+- Wire active StellarWalletsKit instance into wallet implementation for proper kit instance management across connect/disconnect/sign operations
+- Ensure connection state flows correctly through context hooks so useDerivedAccountStatus properly detects wallet connection

--- a/packages/adapter-stellar/src/wallet/stellar-wallets-kit/StellarWalletsKitConnectButton.tsx
+++ b/packages/adapter-stellar/src/wallet/stellar-wallets-kit/StellarWalletsKitConnectButton.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 
 import { logger } from '@openzeppelin/ui-builder-utils';
 
+import { setStellarConnectedAddress } from '../connection';
 import { stellarUiKitManager } from './stellarUiKitManager';
 
 /**
@@ -31,9 +32,31 @@ export function StellarWalletsKitConnectButton() {
       container: containerRef.current,
       onConnect: ({ address }) => {
         logger.info('StellarWalletsKitConnectButton', `Connected to address: ${address}`);
+        // Inform the adapter's wallet implementation so the context updates
+        // This ensures the Execute Transaction button and other components
+        // recognize the wallet connection state
+        try {
+          setStellarConnectedAddress(address ?? null);
+        } catch (error) {
+          logger.warn(
+            'StellarWalletsKitConnectButton',
+            'Failed to set connected address in adapter implementation:',
+            error
+          );
+        }
       },
       onDisconnect: () => {
         logger.info('StellarWalletsKitConnectButton', 'Disconnected');
+        // Inform the implementation we are no longer connected
+        try {
+          setStellarConnectedAddress(null);
+        } catch (error) {
+          logger.warn(
+            'StellarWalletsKitConnectButton',
+            'Failed to clear connected address in adapter implementation:',
+            error
+          );
+        }
       },
       buttonText: 'Connect Wallet',
     });

--- a/packages/adapter-stellar/src/wallet/stellar-wallets-kit/stellarUiKitManager.ts
+++ b/packages/adapter-stellar/src/wallet/stellar-wallets-kit/stellarUiKitManager.ts
@@ -3,6 +3,8 @@ import { allowAllModules, StellarWalletsKit, WalletNetwork } from '@creit.tech/s
 import type { StellarNetworkConfig, UiKitConfiguration } from '@openzeppelin/ui-builder-types';
 import { logger } from '@openzeppelin/ui-builder-utils';
 
+import { getStellarWalletImplementation } from '../utils/stellarWalletImplementationManager';
+
 export interface StellarUiKitManagerState {
   isConfigured: boolean;
   isInitializing: boolean;
@@ -112,6 +114,26 @@ async function configure(newFullUiKitConfig: UiKitConfiguration): Promise<void> 
       state.kitProviderComponent = null;
       state.isKitAssetsLoaded = true;
       state.error = null;
+
+      // Wire the active kit into the wallet implementation
+      // This ensures signing and other operations use the correct kit instance
+      if (state.networkConfig) {
+        try {
+          const impl = await getStellarWalletImplementation(state.networkConfig);
+          impl.setActiveStellarKit(kit);
+          logger.debug(
+            'StellarUiKitManager:configure',
+            'Active kit wired into wallet implementation for stellar-wallets-kit'
+          );
+        } catch (error) {
+          logger.warn(
+            'StellarUiKitManager:configure',
+            'Failed to attach active kit to wallet implementation:',
+            error
+          );
+        }
+      }
+
       logger.info(
         'StellarUiKitManager:configure',
         'Stellar Wallets Kit configured with built-in UI and all wallet modules'
@@ -128,6 +150,26 @@ async function configure(newFullUiKitConfig: UiKitConfiguration): Promise<void> 
       state.kitProviderComponent = null;
       state.isKitAssetsLoaded = true;
       state.error = null;
+
+      // Wire the active kit into the wallet implementation
+      // This ensures signing and other operations use the correct kit instance
+      if (state.networkConfig) {
+        try {
+          const impl = await getStellarWalletImplementation(state.networkConfig);
+          impl.setActiveStellarKit(kit);
+          logger.debug(
+            'StellarUiKitManager:configure',
+            'Active kit wired into wallet implementation for custom'
+          );
+        } catch (error) {
+          logger.warn(
+            'StellarUiKitManager:configure',
+            'Failed to attach active kit to wallet implementation:',
+            error
+          );
+        }
+      }
+
       logger.info(
         'StellarUiKitManager:configure',
         'Stellar Wallets Kit configured for custom UI components'
@@ -138,6 +180,25 @@ async function configure(newFullUiKitConfig: UiKitConfiguration): Promise<void> 
       state.kitProviderComponent = null;
       state.isKitAssetsLoaded = false;
       state.error = null;
+
+      // Clear the active kit from the wallet implementation
+      if (state.networkConfig) {
+        try {
+          const impl = await getStellarWalletImplementation(state.networkConfig);
+          impl.setActiveStellarKit(null);
+          logger.debug(
+            'StellarUiKitManager:configure',
+            'Active kit cleared from wallet implementation for none'
+          );
+        } catch (error) {
+          logger.warn(
+            'StellarUiKitManager:configure',
+            'Failed to clear active kit from wallet implementation:',
+            error
+          );
+        }
+      }
+
       logger.info('StellarUiKitManager:configure', 'UI kit set to "none", no wallet UI provided');
     } else {
       throw new Error(`Unknown UI kit name: ${newKitName}`);

--- a/packages/react-core/src/components/WalletConnectionUI.tsx
+++ b/packages/react-core/src/components/WalletConnectionUI.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { Button } from '@openzeppelin/ui-builder-ui';
 import { cn, logger } from '@openzeppelin/ui-builder-utils';
@@ -24,8 +24,8 @@ export const WalletConnectionUI: React.FC<WalletConnectionUIProps> = ({ classNam
     });
   }, [activeAdapter, walletFacadeHooks]);
 
-  // Memoize wallet components to avoid unnecessary re-renders
-  const walletComponents = useMemo(() => {
+  // Compute wallet components on each render to ensure UI kit changes are reflected immediately
+  const walletComponents = (() => {
     if (!activeAdapter || typeof activeAdapter.getEcosystemWalletComponents !== 'function') {
       logger.debug(
         'WalletConnectionUI',
@@ -43,7 +43,7 @@ export const WalletConnectionUI: React.FC<WalletConnectionUIProps> = ({ classNam
       setIsError(true);
       return null;
     }
-  }, [activeAdapter]);
+  })();
 
   if (!walletComponents) {
     logger.debug(
@@ -71,16 +71,6 @@ export const WalletConnectionUI: React.FC<WalletConnectionUIProps> = ({ classNam
         </Button>
       </div>
     );
-  }
-
-  // Ensure walletComponents is not null before destructuring
-  if (!walletComponents) {
-    // This case should ideally be caught above, but as a safeguard:
-    logger.debug(
-      'WalletConnectionUI',
-      '[Debug] walletComponents is null before rendering, rendering null.'
-    );
-    return null;
   }
 
   return (


### PR DESCRIPTION
## Summary

This PR fixes two related issues with the Stellar adapter's UI kit integration:

1. **UI Kit Switching Issue**: When toggling between "Stellar Wallets Kit Custom" and "Stellar Wallets Kit" in the UI Builder, the wallet header components weren't updating to reflect the new kit.

2. **Execute Transaction Button Issue**: When using "Stellar Wallets Kit", the Execute Transaction button didn't enable after connecting a wallet and filling in form fields.

## Root Causes

1. **WalletConnectionUI** was memoizing wallet components based only on `activeAdapter`, which doesn't change when switching UI kits. The memoization prevented recomputation of components when the kit configuration changed.

2. **StellarWalletsKitConnectButton** wasn't propagating connection state changes to the adapter's wallet implementation. When the native button connected/disconnected, it only logged the events but didn't update the adapter's internal state, so the React context and hooks never knew the wallet was connected.

## Changes

### `packages/react-core/src/components/WalletConnectionUI.tsx`
- Replaced `useMemo` with direct computation on each render
- Ensures wallet components are recomputed when UI kit configuration changes
- Fixes UI kit switching for all adapters (not just Stellar)

### `packages/adapter-stellar/src/wallet/stellar-wallets-kit/StellarWalletsKitConnectButton.tsx`
- Added `setStellarConnectedAddress()` calls in `onConnect` and `onDisconnect` callbacks
- Ensures connection state propagates to adapter's wallet implementation
- Enables Execute Transaction button to detect wallet connection correctly

### `packages/adapter-stellar/src/wallet/stellar-wallets-kit/stellarUiKitManager.ts`
- Wire active `StellarWalletsKit` instance into wallet implementation for both `'stellar-wallets-kit'` and `'custom'` modes
- Ensures signing and other operations use the correct kit instance
- Added cleanup for `'none'` mode to clear active kit

## Testing

1. ✅ Toggle between "Stellar Wallets Kit Custom" and "Stellar Wallets Kit" - header should update immediately
2. ✅ Connect wallet using "Stellar Wallets Kit" - Execute Transaction button should enable when form is valid
3. ✅ Disconnect wallet - Execute Transaction button should disable
4. ✅ Same fixes work for EVM adapter (RainbowKit vs Wagmi Custom)

## Impact

- **Packages**: `@openzeppelin/ui-builder-adapter-stellar`, `@openzeppelin/ui-builder-react-core`
- **Version**: Patch (bug fixes)
- **Breaking Changes**: None

