### PR TITLE
fix(builder, export): preventing unnecessary remounts in exported apps

### DIFF
--- a/packages/builder/src/export/__tests__/ExportSnapshotTests.test.ts
+++ b/packages/builder/src/export/__tests__/ExportSnapshotTests.test.ts
@@ -146,19 +146,19 @@ describe('Export Snapshot Tests', () => {
       const evmFormComponent = prepareForSnapshot(evmFiles.formComponent);
       const solanaFormComponent = prepareForSnapshot(solanaFiles.formComponent);
 
-      // Both should be React components
+      // Both should be React components with useMemo import
       expect(evmFormComponent).toContain('import');
-      expect(evmFormComponent).toContain("from 'react'");
+      expect(evmFormComponent).toMatch(/import.*useMemo.*from ['"]react['"]/);
       expect(solanaFormComponent).toContain('import');
-      expect(solanaFormComponent).toContain("from 'react'");
+      expect(solanaFormComponent).toMatch(/import.*useMemo.*from ['"]react['"]/);
 
       // Both should render TransactionForm
       expect(evmFormComponent).toMatch(/return\s*\([\s\S]*?<TransactionForm/);
       expect(solanaFormComponent).toMatch(/return\s*\([\s\S]*?<TransactionForm/);
 
-      // Both should have similar form schema structures
-      expect(evmFormComponent).toMatch(/const formSchema/);
-      expect(solanaFormComponent).toMatch(/const formSchema/);
+      // Both should have similar form schema structures with useMemo
+      expect(evmFormComponent).toMatch(/const formSchema.*useMemo/);
+      expect(solanaFormComponent).toMatch(/const formSchema.*useMemo/);
     });
 
     it('should verify App component similarities across chains', async () => {

--- a/packages/builder/src/export/__tests__/FormComponentTests.test.ts
+++ b/packages/builder/src/export/__tests__/FormComponentTests.test.ts
@@ -70,8 +70,8 @@ describe('Form Component Tests', () => {
     it('should generate a valid React component with proper imports', async () => {
       const { formComponentCode } = await extractFormComponent('evm');
 
-      // Check for React import (modern React doesn't require default import)
-      expect(formComponentCode).toMatch(/import.*from ['"]react['"]/);
+      // Check for React import with useMemo (modern React doesn't require default import)
+      expect(formComponentCode).toMatch(/import.*useMemo.*from ['"]react['"]/);
 
       // Check for TransactionForm import - handle multi-line imports
       expect(formComponentCode).toContain('TransactionForm');
@@ -110,8 +110,11 @@ describe('Form Component Tests', () => {
     it('should transform builder config to render schema correctly', async () => {
       const { formComponentCode } = await extractFormComponent('evm', 'transfer');
 
-      // Check for schema declaration
-      expect(formComponentCode).toMatch(/const formSchema: RenderFormSchema =/);
+      // Check for schema declaration with useMemo (memoized to prevent form resets)
+      expect(formComponentCode).toMatch(/const formSchema: RenderFormSchema = useMemo/);
+
+      // Check for useMemo import
+      expect(formComponentCode).toMatch(/import.*useMemo.*from ['"]react['"]/);
 
       // Check for fields array in the TypeScript format
       expect(formComponentCode).toMatch(/fields:\s*\[/);

--- a/packages/builder/src/export/__tests__/__snapshots__/ExportSnapshotTests.test.ts.snap
+++ b/packages/builder/src/export/__tests__/__snapshots__/ExportSnapshotTests.test.ts.snap
@@ -15,11 +15,14 @@ exports[`Export Snapshot Tests > Conditional File Modifications > should modify 
 `;
 
 exports[`Export Snapshot Tests > EVM Export Snapshots > should match snapshot for App component > app-component-evm 1`] = `
-"import {
+"import { useEffect, useState } from 'react';
+
+import {
   useDerivedAccountStatus,
   useWalletState,
   WalletConnectionWithSettings,
 } from '@openzeppelin/ui-builder-react-core';
+import type { ContractAdapter } from '@openzeppelin/ui-builder-types';
 import { Footer } from '@openzeppelin/ui-builder-ui';
 
 import GeneratedForm from './components/GeneratedForm';
@@ -29,21 +32,22 @@ import GeneratedForm from './components/GeneratedForm';
  *
  * Main application component that wraps the form.
  * Uses useWalletState to get the active adapter.
+ * Caches the adapter once available to prevent form remounts during wallet connection.
  */
 export function App() {
-  const { activeAdapter, isAdapterLoading } = useWalletState();
+  const { activeAdapter } = useWalletState();
   const { isConnected: isWalletConnectedForForm } = useDerivedAccountStatus();
 
-  if (isAdapterLoading) {
-    return <div className="app-loading">Loading adapter...</div>;
-  }
-  if (!activeAdapter) {
-    return (
-      <div className="app-error">
-        Adapter not available. Please ensure network is selected and supported.
-      </div>
-    );
-  }
+  // Persist the adapter used by the form once it first becomes available to avoid remounts
+  // This prevents form resets when the adapter briefly transitions during wallet connection
+  const [adapterForForm, setAdapterForForm] = useState<ContractAdapter | null>(null);
+
+  useEffect(() => {
+    if (activeAdapter) {
+      // Don't replace an existing adapter instance to keep the form mounted
+      setAdapterForForm((prev) => prev ?? activeAdapter);
+    }
+  }, [activeAdapter]);
 
   return (
     <div className="app">
@@ -65,7 +69,12 @@ export function App() {
 
       <main className="main">
         <div className="container">
-          <GeneratedForm adapter={activeAdapter} isWalletConnected={isWalletConnectedForForm} />
+          {adapterForForm ? (
+            <GeneratedForm adapter={adapterForForm} isWalletConnected={isWalletConnectedForForm} />
+          ) : (
+            // Only shown before the first adapter resolves, never shown again
+            <div className="app-loading">Loading adapter...</div>
+          )}
         </div>
       </main>
 
@@ -79,7 +88,7 @@ export function App() {
 exports[`Export Snapshot Tests > EVM Export Snapshots > should match snapshot for EVM adapter > evm-adapter 1`] = `""`;
 
 exports[`Export Snapshot Tests > EVM Export Snapshots > should match snapshot for Form component > form-component-evm 1`] = `
-"import { useState } from 'react';
+"import { useMemo, useState } from 'react';
 
 import {
   ContractActionBar,
@@ -93,6 +102,7 @@ import type {
   RenderFormSchema,
 } from '@openzeppelin/ui-builder-types';
 import { Card, CardContent } from '@openzeppelin/ui-builder-ui';
+import { cn } from '@openzeppelin/ui-builder-utils';
 
 // Props for GeneratedForm
 interface GeneratedFormProps {
@@ -116,74 +126,84 @@ export default function GeneratedForm({ adapter, isWalletConnected }: GeneratedF
   */
   const [isWidgetVisible, setIsWidgetVisible] = useState(false);
   const [loadError, _setLoadError] = useState<Error | null>(null);
+
   // Form schema generated from the builder and transformed by FormSchemaFactory
-  const formSchema: RenderFormSchema = {
-    functionId: 'transfer',
-    layout: {
-      columns: 1,
-      spacing: 'normal',
-      labelPosition: 'top',
-    },
-    validation: {
-      mode: 'onChange',
-      showErrors: 'inline',
-    },
-    theme: {},
-    contractAddress: '0xe34139463bA50bD61336E0c446Bd8C0867c6fE65',
-    id: 'form-transfer',
-    title: 'Transfer',
-    description: 'Form for interacting with the Transfer function.',
-    fields: [
-      {
-        id: '[id]',
-        name: 'testParam',
-        label: 'Test Parameter',
-        type: 'text',
-        placeholder: 'Enter test parameter',
-        helperText: 'Description for Test Parameter',
-        validation: {
-          required: true,
-        },
+  // Memoized to maintain stable reference across re-renders and prevent form resets
+  const formSchema: RenderFormSchema = useMemo(() => {
+    return {
+      functionId: 'transfer',
+      layout: {
+        columns: 1,
+        spacing: 'normal',
+        labelPosition: 'top',
       },
-    ],
-    submitButton: {
-      text: 'Execute Transfer',
-      loadingText: 'Processing...',
-      variant: 'primary',
-    },
-  }; /*@@FORM_SCHEMA_JSON@@*/
+      validation: {
+        mode: 'onChange',
+        showErrors: 'inline',
+      },
+      theme: {},
+      contractAddress: '0xe34139463bA50bD61336E0c446Bd8C0867c6fE65',
+      id: 'form-transfer',
+      title: 'Transfer',
+      description: 'Form for interacting with the Transfer function.',
+      fields: [
+        {
+          id: '[id]',
+          name: 'testParam',
+          label: 'Test Parameter',
+          type: 'text',
+          placeholder: 'Enter test parameter',
+          helperText: 'Description for Test Parameter',
+          validation: {
+            required: true,
+          },
+        },
+      ],
+      submitButton: {
+        text: 'Execute Transfer',
+        loadingText: 'Processing...',
+        variant: 'primary',
+      },
+    };
+  }, []);
 
   // Contract schema injected by generator (loaded or imported by the user)
-  const contractSchema: ContractSchema = {
-    ecosystem: 'evm',
-    name: 'MockContract',
-    address: '0x1234567890123456789012345678901234567890',
-    functions: [
-      {
-        id: 'transfer',
-        name: 'transfer',
-        displayName: 'Transfer',
-        inputs: [],
-        type: 'function',
-        modifiesState: true,
-      },
-      {
-        id: 'viewFunction',
-        name: 'viewFunction',
-        displayName: 'View Function',
-        inputs: [],
-        type: 'function',
-        modifiesState: false,
-        stateMutability: 'view',
-      },
-    ],
-  };
+  // Memoized to maintain stable reference across re-renders and prevent form resets
+  const contractSchema: ContractSchema = useMemo(() => {
+    return {
+      ecosystem: 'evm',
+      name: 'MockContract',
+      address: '0x1234567890123456789012345678901234567890',
+      functions: [
+        {
+          id: 'transfer',
+          name: 'transfer',
+          displayName: 'Transfer',
+          inputs: [],
+          type: 'function',
+          modifiesState: true,
+        },
+        {
+          id: 'viewFunction',
+          name: 'viewFunction',
+          displayName: 'View Function',
+          inputs: [],
+          type: 'function',
+          modifiesState: false,
+          stateMutability: 'view',
+        },
+      ],
+    };
+  }, []);
 
   // Execution configuration selected in the builder
-  const executionConfig: ExecutionConfig | undefined = {
-    method: 'eoa',
-    allowAny: true,
-  };
+  // Memoized to maintain stable reference across re-renders
+  const executionConfig: ExecutionConfig | undefined = useMemo(() => {
+    return {
+      method: 'eoa',
+      allowAny: true,
+    };
+  }, []);
 
   const contractAddress = formSchema.contractAddress;
 
@@ -234,9 +254,14 @@ export default function GeneratedForm({ adapter, isWalletConnected }: GeneratedF
       )}
 
       <div className="flex gap-4">
-        {/* Contract State Widget on the left side - matching builder app layout */}
-        {contractAddress && isWidgetVisible && (
-          <div className="w-[300px] flex-shrink-0">
+        {/* Contract State Widget on the left side - always mounted to prevent remount churn */}
+        {contractAddress && (
+          <div
+            className={cn(
+              'shrink-0 transition-all',
+              isWidgetVisible ? 'md:w-80 md:mr-6' : 'md:w-0'
+            )}
+          >
             <div className="sticky top-4">
               <ContractStateWidget
                 contractSchema={schemaToUse}

--- a/packages/builder/src/export/codeTemplates/form-component.template.tsx
+++ b/packages/builder/src/export/codeTemplates/form-component.template.tsx
@@ -6,7 +6,7 @@
  * - "@@param-name@@" - Template variable markers (consistent across all templates)
  */
 /*------------TEMPLATE COMMENT END------------*/
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import {
   ContractActionBar,
@@ -20,6 +20,7 @@ import type {
   RenderFormSchema,
 } from '@openzeppelin/ui-builder-types';
 import { Card, CardContent } from '@openzeppelin/ui-builder-ui';
+import { cn } from '@openzeppelin/ui-builder-utils';
 
 // Props for GeneratedForm
 interface GeneratedFormProps {
@@ -43,28 +44,38 @@ export default function GeneratedForm({ adapter, isWalletConnected }: GeneratedF
   */
   const [isWidgetVisible, setIsWidgetVisible] = useState(false);
   const [loadError, _setLoadError] = useState<Error | null>(null);
+
   // Form schema generated from the builder and transformed by FormSchemaFactory
+  // Memoized to maintain stable reference across re-renders and prevent form resets
   /*------------TEMPLATE COMMENT START------------*/
   // This is an empty object that will be replaced at generation time with a properly
   // transformed RenderFormSchema that includes all necessary properties
   /*------------TEMPLATE COMMENT END------------*/
   // @ts-expect-error - Placeholder
-  const formSchema: RenderFormSchema = {}; /*@@FORM_SCHEMA_JSON@@*/
+  const formSchema: RenderFormSchema = useMemo(() => {
+    return {}; /*@@FORM_SCHEMA_JSON@@*/
+  }, []);
 
   // Contract schema injected by generator (loaded or imported by the user)
+  // Memoized to maintain stable reference across re-renders and prevent form resets
   /*------------TEMPLATE COMMENT START------------*/
   // This is an empty object that will be replaced at generation time with a properly
   // transformed ContractSchema that includes all necessary properties
   /*------------TEMPLATE COMMENT END------------*/
   // @ts-expect-error - Placeholder
-  const contractSchema: ContractSchema = {}; /*@@CONTRACT_SCHEMA_JSON@@*/
+  const contractSchema: ContractSchema = useMemo(() => {
+    return {}; /*@@CONTRACT_SCHEMA_JSON@@*/
+  }, []);
 
   // Execution configuration selected in the builder
+  // Memoized to maintain stable reference across re-renders
   /*------------TEMPLATE COMMENT START------------*/
   // This will be replaced at generation time with the stringified ExecutionConfig or 'undefined'.
   // Use 'unknown' for the placeholder type. Assign undefined and use comment marker for replacement.
   /*------------TEMPLATE COMMENT END------------*/
-  const executionConfig: ExecutionConfig | undefined = undefined; /*@@EXECUTION_CONFIG_JSON@@*/
+  const executionConfig: ExecutionConfig | undefined = useMemo(() => {
+    return undefined; /*@@EXECUTION_CONFIG_JSON@@*/
+  }, []);
 
   const contractAddress = formSchema.contractAddress;
 
@@ -115,9 +126,14 @@ export default function GeneratedForm({ adapter, isWalletConnected }: GeneratedF
       )}
 
       <div className="flex gap-4">
-        {/* Contract State Widget on the left side - matching builder app layout */}
-        {contractAddress && isWidgetVisible && (
-          <div className="w-[300px] flex-shrink-0">
+        {/* Contract State Widget on the left side - always mounted to prevent remount churn */}
+        {contractAddress && (
+          <div
+            className={cn(
+              'shrink-0 transition-all',
+              isWidgetVisible ? 'md:w-80 md:mr-6' : 'md:w-0'
+            )}
+          >
             <div className="sticky top-4">
               <ContractStateWidget
                 contractSchema={schemaToUse}

--- a/packages/builder/src/export/generators/TemplateProcessor.ts
+++ b/packages/builder/src/export/generators/TemplateProcessor.ts
@@ -223,9 +223,10 @@ export class TemplateProcessor {
       try {
         // We can inject the JSON directly without parsing and re-stringifying
         // Prettier will format it properly at the end
+        // Replace the return statement inside useMemo
         processedTemplate = processedTemplate.replace(
-          /const formSchema: RenderFormSchema = \{\};/g,
-          `const formSchema: RenderFormSchema = ${options.formConfigJSON};`
+          /return \{\}; \/\*@@FORM_SCHEMA_JSON@@\*\//g,
+          `return ${options.formConfigJSON};`
         );
       } catch (error) {
         logger.error('TemplateProcessor', 'Failed to inject form schema:', error);
@@ -236,10 +237,10 @@ export class TemplateProcessor {
     // Inject ContractSchema JSON if provided
     if (options?.contractSchemaJSON) {
       try {
+        // Replace the return statement inside useMemo
         processedTemplate = processedTemplate.replace(
-          // Assume a similar placeholder variable assignment
-          /const contractSchema: ContractSchema = \{\}; \/\*@@CONTRACT_SCHEMA_JSON@@\*\//g,
-          `const contractSchema: ContractSchema = ${options.contractSchemaJSON};`
+          /return \{\}; \/\*@@CONTRACT_SCHEMA_JSON@@\*\//g,
+          `return ${options.contractSchemaJSON};`
         );
       } catch (error) {
         logger.error('TemplateProcessor', 'Failed to inject contract schema:', error);
@@ -250,10 +251,11 @@ export class TemplateProcessor {
     // Inject execution config JSON if provided
     if (options?.executionConfigJSON) {
       try {
-        const regex =
-          /const executionConfig: ExecutionConfig \| undefined = undefined; \/\*@@EXECUTION_CONFIG_JSON@@\*\//g;
-        const replacement = `const executionConfig: ExecutionConfig | undefined = ${options.executionConfigJSON};`;
-        processedTemplate = processedTemplate.replace(regex, replacement);
+        // Replace the return statement inside useMemo
+        processedTemplate = processedTemplate.replace(
+          /return undefined; \/\*@@EXECUTION_CONFIG_JSON@@\*\//g,
+          `return ${options.executionConfigJSON};`
+        );
       } catch (error) {
         logger.error('TemplateProcessor', 'Failed to inject execution config:', error);
         throw error;

--- a/packages/builder/src/export/generators/__tests__/AppCodeGenerator.templating.test.ts
+++ b/packages/builder/src/export/generators/__tests__/AppCodeGenerator.templating.test.ts
@@ -359,9 +359,12 @@ function example() {
 
     it('should format the form schema correctly when injecting it', async () => {
       const template = `
+        import { useMemo } from 'react';
         import { RenderFormSchema } from '../types';
         
-        const formSchema: RenderFormSchema = {};
+        const formSchema: RenderFormSchema = useMemo(() => {
+          return {}; /*@@FORM_SCHEMA_JSON@@*/
+        }, []);
         
         function renderForm() {
           return renderWithSchema(formSchema);
@@ -394,9 +397,8 @@ function example() {
         formConfigJSON: JSON.stringify(formConfig),
       });
 
-      // The processed output should have the JSON inserted, but not yet formatted
-      // We'll format the entire code later with formatFinalCode
-      expect(processed).toContain('const formSchema: RenderFormSchema = {');
+      // The processed output should have the JSON inserted inside useMemo
+      expect(processed).toContain('const formSchema: RenderFormSchema = useMemo');
 
       // We now just check for the existence of these properties in any format
       expect(processed).toContain('functionId');
@@ -494,9 +496,12 @@ const anotherFunction = () => {
 
     it('should inject form schema when formConfigJSON is provided', async () => {
       const template = `
+        import { useMemo } from 'react';
         import { RenderFormSchema } from '../types';
         
-        const formSchema: RenderFormSchema = {};
+        const formSchema: RenderFormSchema = useMemo(() => {
+          return {}; /*@@FORM_SCHEMA_JSON@@*/
+        }, []);
         
         function renderForm() {
           return renderWithSchema(formSchema);
@@ -513,9 +518,10 @@ const anotherFunction = () => {
         formConfigJSON: JSON.stringify(formConfig),
       });
 
-      // Check that JSON was inserted correctly in any format
-      expect(processed).not.toContain('const formSchema: RenderFormSchema = {};');
-      expect(processed).toContain('const formSchema: RenderFormSchema = {');
+      // Check that JSON was inserted correctly inside useMemo
+      expect(processed).not.toContain('return {}; /*@@FORM_SCHEMA_JSON@@*/');
+      expect(processed).toContain('const formSchema: RenderFormSchema = useMemo');
+      expect(processed).toContain('return {');
 
       // Check for these properties in any format
       expect(processed).toContain('fields');


### PR DESCRIPTION
Updated tests to check for useMemo imports and schema declarations. Adjusted template processing to inject form and contract schemas within useMemo, ensuring stable references across re-renders. Enhanced App component to cache adapter state, preventing unnecessary remounts during wallet connection.

Fixes: https://github.com/OpenZeppelin/ui-builder/issues/175