### PR TITLE
fix: resolve TypeScript error in xdr-ordering utility

### DIFF
--- a/packages/adapter-stellar/src/utils/xdr-ordering.ts
+++ b/packages/adapter-stellar/src/utils/xdr-ordering.ts
@@ -26,9 +26,11 @@ function getBytes(scVal: xdr.ScVal): Uint8Array {
     return xdrValue;
   }
 
-  const result = new Uint8Array(xdrValue.length);
-  for (let index = 0; index < xdrValue.length; index += 1) {
-    result[index] = xdrValue[index];
+  // Handle array-like objects (e.g., Buffer in Node.js)
+  const arrayLike = xdrValue as ArrayLike<number>;
+  const result = new Uint8Array(arrayLike.length);
+  for (let index = 0; index < arrayLike.length; index += 1) {
+    result[index] = arrayLike[index];
   }
   return result;
 }


### PR DESCRIPTION
## Summary

Fixes TypeScript compilation error in the  utility that was causing CI to fail.

## Issue
TypeScript was unable to infer the type of `xdrValue` after the `instanceof Uint8Array` check, resulting in:
```
error TS2339: Property 'length' does not exist on type 'never'
```

## Fix
- Cast `xdrValue` to `ArrayLike<number>` when it's not a Uint8Array
- This allows TypeScript to understand the array-like interface
- Maintains cross-platform compatibility for both Browser (Uint8Array) and Node.js (Buffer) environments

## Testing
- ✅ TypeScript compilation passes
- ✅ Adapter tests pass
- ✅ Cross-platform compatibility maintained