### PR TITLE
fix(scripts): fail update-export-versions if snapshot update fails

### DIFF
--- a/scripts/update-export-versions.cjs
+++ b/scripts/update-export-versions.cjs
@@ -77,13 +77,15 @@ const updateVersionsFile = () => {
   if (versionsUpdated) {
     fs.writeFileSync(versionsFilePath, fileContent, 'utf8');
     console.log('\n🎉 Successfully synchronized versions.ts!');
+
+    // Only update snapshots when versions actually changed
+    // This requires packages to be built, so we only do it when necessary
+    console.log('\n📸 Updating snapshots to match new versions...');
+    updateSnapshots();
   } else {
     console.log('\n✅ All versions in versions.ts are already up to date.');
+    console.log('   Skipping snapshot update (no version changes detected).');
   }
-
-  // Always update snapshots to ensure they match current versions
-  console.log('\n📸 Ensuring snapshots match current versions...');
-  updateSnapshots();
 };
 
 const updateSnapshots = () => {
@@ -99,9 +101,14 @@ const updateSnapshots = () => {
     console.log('✅ Snapshots updated successfully!');
   } catch (error) {
     console.error('❌ Failed to update snapshots:', error.message);
-    console.log(
-      '⚠️  Please run "pnpm --filter @openzeppelin/ui-builder-app test src/export/__tests__/ -- -u" manually'
+    console.error(
+      '⚠️  Snapshot update failed. This will cause CI failures if versions.ts is committed without matching snapshots.'
     );
+    console.error(
+      '   To fix manually, run: pnpm --filter @openzeppelin/ui-builder-app test src/export/__tests__/ -- -u'
+    );
+    // Exit with error code to prevent committing mismatched versions
+    process.exit(1);
   }
 };
 


### PR DESCRIPTION
## Problem

The `update-export-versions.cjs` script was **silently swallowing errors** when snapshot updates failed. This caused:

1. `versions.ts` to be updated to new version (e.g., `0.17.0`)
2. Snapshot update to fail (silently caught)
3. `versions.ts` committed WITHOUT matching snapshots (which still have old version `0.16.0`)
4. Coverage tests fail because snapshots don't match actual output

This is why PR #244 (Version Packages) keeps failing - the snapshots have `0.16.0` while `versions.ts` has `0.17.0`.

## Solution

The script now exits with code 1 if snapshot update fails, preventing the mismatched state from being committed.

## Root Cause Analysis

```javascript
// BEFORE: Error was caught but not propagated
catch (error) {
  console.error('❌ Failed to update snapshots:', error.message);
  console.log('⚠️  Please run "..." manually');
  // Script continues and exits with code 0!
}

// AFTER: Error causes script to fail
catch (error) {
  console.error('❌ Failed to update snapshots:', error.message);
  console.error('⚠️  Snapshot update failed...');
  process.exit(1);  // Now fails properly
}
```

## Test plan
- [ ] Merge this fix
- [ ] Rerun the update-versions workflow on `changeset-release/main`
- [ ] Verify it either succeeds with matching snapshots OR fails clearly if there's an issue