### PR TITLE
fix(builder): add adapter package aliases to vitest config

### DIFF
--- a/packages/builder/vitest.config.ts
+++ b/packages/builder/vitest.config.ts
@@ -103,25 +103,30 @@ export default defineConfig(
       alias: {
         '@': path.resolve(__dirname, './src'),
         '@styles': path.resolve(__dirname, '../styles'),
-        '@openzeppelin/ui-builder-utils': path.resolve(
-          __dirname,
-          '../utils/src/index.ts'
-        ),
+        '@openzeppelin/ui-builder-utils': path.resolve(__dirname, '../utils/src/index.ts'),
         '@openzeppelin/ui-builder-react-core': path.resolve(
           __dirname,
           '../react-core/dist/index.js'
         ),
-        '@openzeppelin/ui-builder-ui': path.resolve(
+        '@openzeppelin/ui-builder-ui': path.resolve(__dirname, '../ui/dist/index.js'),
+        '@openzeppelin/ui-builder-types': path.resolve(__dirname, '../types/dist/index.js'),
+        '@openzeppelin/ui-builder-renderer': path.resolve(__dirname, '../renderer/dist/index.js'),
+        // Adapter packages - required for export tests that use ecosystemManager
+        '@openzeppelin/ui-builder-adapter-evm': path.resolve(
           __dirname,
-          '../ui/dist/index.js'
+          '../adapter-evm/dist/index.js'
         ),
-        '@openzeppelin/ui-builder-types': path.resolve(
+        '@openzeppelin/ui-builder-adapter-solana': path.resolve(
           __dirname,
-          '../types/dist/index.js'
+          '../adapter-solana/dist/index.js'
         ),
-        '@openzeppelin/ui-builder-renderer': path.resolve(
+        '@openzeppelin/ui-builder-adapter-stellar': path.resolve(
           __dirname,
-          '../renderer/dist/index.js'
+          '../adapter-stellar/dist/index.js'
+        ),
+        '@openzeppelin/ui-builder-adapter-midnight': path.resolve(
+          __dirname,
+          '../adapter-midnight/dist/index.js'
         ),
       },
       dedupe: [
@@ -129,6 +134,10 @@ export default defineConfig(
         '@openzeppelin/ui-builder-types',
         '@openzeppelin/ui-builder-react-core',
         '@openzeppelin/ui-builder-ui',
+        '@openzeppelin/ui-builder-adapter-evm',
+        '@openzeppelin/ui-builder-adapter-solana',
+        '@openzeppelin/ui-builder-adapter-stellar',
+        '@openzeppelin/ui-builder-adapter-midnight',
         'react',
         'react-dom',
       ],
@@ -140,6 +149,10 @@ export default defineConfig(
         '@openzeppelin/ui-builder-types',
         '@openzeppelin/ui-builder-react-core',
         '@openzeppelin/ui-builder-ui',
+        '@openzeppelin/ui-builder-adapter-evm',
+        '@openzeppelin/ui-builder-adapter-solana',
+        '@openzeppelin/ui-builder-adapter-stellar',
+        '@openzeppelin/ui-builder-adapter-midnight',
       ],
     },
     // Add ssr.noExternal to ensure these are not treated as external during test SSR phase
@@ -149,6 +162,10 @@ export default defineConfig(
         '@openzeppelin/ui-builder-types',
         '@openzeppelin/ui-builder-react-core',
         '@openzeppelin/ui-builder-ui',
+        '@openzeppelin/ui-builder-adapter-evm',
+        '@openzeppelin/ui-builder-adapter-solana',
+        '@openzeppelin/ui-builder-adapter-stellar',
+        '@openzeppelin/ui-builder-adapter-midnight',
       ],
     },
     test: {


### PR DESCRIPTION
## Problem

The export tests were failing in the `update-versions.yml` workflow with:

```
Error: Failed to resolve entry for package "@openzeppelin/ui-builder-adapter-evm". 
The package may have incorrect main/module/exports specified in its package.json.
```

This was happening because the adapter packages weren't included in the vitest config's `resolve.alias` configuration. When Vitest tries to resolve these workspace packages, it needs explicit aliases to find the built `dist/index.js` files.

## Solution

Added aliases for all adapter packages (evm, solana, stellar, midnight) to:
- `resolve.alias` - maps package names to their dist entry points
- `dedupe` - prevents duplicate package instances
- `optimizeDeps.include` - pre-bundles for faster tests
- `ssr.noExternal` - ensures proper handling in test SSR phase

## Related

This fixes the underlying issue that was preventing PR #244 (Version Packages) from succeeding. After merging:
1. The `update-versions.yml` workflow should be able to run the export tests
2. Snapshots will be properly updated to 0.17.0
3. The Version Packages PR can be merged

## Test plan
- [ ] CI passes on this PR
- [ ] Rerun the `update-versions` workflow on `changeset-release/main` after merging
- [ ] Verify snapshots are updated and PR #244 succeeds