### PR TITLE
fix(scripts): correct vitest flag position in update-export-versions

### DIFF
--- a/scripts/update-export-versions.cjs
+++ b/scripts/update-export-versions.cjs
@@ -94,10 +94,15 @@ const updateSnapshots = () => {
 
   try {
     // Update snapshots for the export tests specifically (these are the tests that use package versions)
-    execSync('pnpm --filter @openzeppelin/ui-builder-app test src/export/__tests__/ -- -u', {
-      cwd: path.resolve(__dirname, '..'),
-      stdio: 'inherit',
-    });
+    // Note: We use `exec vitest run -u` instead of `test -- -u` because the -u flag must come
+    // before the test path for vitest to recognize it as the update snapshots flag
+    execSync(
+      'pnpm --filter @openzeppelin/ui-builder-app exec vitest run -u src/export/__tests__/',
+      {
+        cwd: path.resolve(__dirname, '..'),
+        stdio: 'inherit',
+      }
+    );
     console.log('✅ Snapshots updated successfully!');
   } catch (error) {
     console.error('❌ Failed to update snapshots:', error.message);
@@ -105,7 +110,7 @@ const updateSnapshots = () => {
       '⚠️  Snapshot update failed. This will cause CI failures if versions.ts is committed without matching snapshots.'
     );
     console.error(
-      '   To fix manually, run: pnpm --filter @openzeppelin/ui-builder-app test src/export/__tests__/ -- -u'
+      '   To fix manually, run: pnpm --filter @openzeppelin/ui-builder-app exec vitest run -u src/export/__tests__/'
     );
     // Exit with error code to prevent committing mismatched versions
     process.exit(1);


### PR DESCRIPTION
## Summary

- Fix the vitest `-u` (update snapshots) flag position in `update-export-versions.cjs`
- The flag was placed after `--` which caused vitest to not recognize it

## Root Cause

The command was:
```
pnpm --filter ... test src/export/__tests__/ -- -u
```

Which translates to `vitest run src/export/__tests__/ -- -u`. Vitest doesn't recognize `-u` when it comes after `--`.

## Fix

Changed to:
```
pnpm --filter ... exec vitest run -u src/export/__tests__/
```

This correctly places `-u` before the test path, allowing vitest to recognize it as the update snapshots flag.

## Why This Broke

The `update-versions.yml` workflow runs on `changeset-release/*` PRs and is supposed to:
1. Detect version mismatches between `package.json` and `versions.ts`
2. Update `versions.ts`
3. Run snapshot tests with `-u` to update them
4. Commit the changes

Step 3 was silently failing because the snapshots weren't being updated (vitest didn't recognize the `-u` flag), causing the tests to fail instead of update.

## Test Plan

- [x] Tested locally by simulating version mismatch - script now correctly updates both `versions.ts` and snapshots
- [ ] CI passes