### PR TITLE
fix(ci): add build step to check-versions workflow

### DIFF
--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
       - develop
-      - 'release/**'
+      - "release/**"
 
 permissions:
   contents: read
@@ -63,6 +63,11 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Build all packages
+        run: pnpm run build
+        env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
 
       - name: Update export versions
         run: pnpm run update-export-versions


### PR DESCRIPTION
## Summary

- Add missing build step to `check-versions.yml` workflow
- The workflow runs `update-export-versions` which needs built packages to run tests

## Problem

The `check-versions` workflow was failing on the changeset-release PR with:
```
Error: Failed to resolve import "@openzeppelin/ui-builder-adapter-evm"
```

## Root Cause

The `update-export-versions` script runs vitest tests **only when versions change**. The vitest plugin resolves adapter imports to `../adapter-evm/dist/index.js`, which requires packages to be built.

| PR Type | Versions Match? | Tests Run? | Build Needed? |
|---------|-----------------|------------|---------------|
| Regular PR | ✅ Yes | No | No |
| Changeset Release | ❌ No | **Yes** | **Yes** |

This is why it worked before - regular PRs never triggered tests because versions were always in sync. Only the changeset-release PR has mismatched versions.

## Fix

Add the build step (matching `update-versions.yml`):
```yaml
- name: Build all packages
  run: pnpm run build
  env:
    NODE_OPTIONS: '--max-old-space-size=8192'
```

## Test Plan

- [ ] CI passes on this PR
- [ ] Changeset release PR (#244) CI passes after this is merged