### PR TITLE
feat(utils): add indexer endpoint env var support to AppConfigService

### DIFF
--- a/packages/utils/src/AppConfigService.ts
+++ b/packages/utils/src/AppConfigService.ts
@@ -72,6 +72,7 @@ export class AppConfigService {
     const loadedNetworkServiceConfigs: NetworkServiceConfigs = {};
     const loadedGlobalServiceConfigs: GlobalServiceConfigs = {};
     const loadedRpcEndpoints: NetworkSpecificRpcEndpoints = {};
+    const loadedIndexerEndpoints: Record<string, string> = {};
     const loadedFeatureFlags: FeatureFlags = {};
 
     for (const key in env) {
@@ -134,6 +135,13 @@ export class AppConfigService {
             loadedRpcEndpoints[networkId] = value;
             logger.debug(LOG_SYSTEM, `Loaded RPC override for ${networkId}: ${value}`);
           }
+        } else if (key.startsWith(`${VITE_ENV_PREFIX}INDEXER_ENDPOINT_`)) {
+          const networkIdSuffix = key.substring(`${VITE_ENV_PREFIX}INDEXER_ENDPOINT_`.length);
+          const networkId = networkIdSuffix.toLowerCase().replace(/_/g, '-');
+          if (networkId) {
+            loadedIndexerEndpoints[networkId] = value;
+            logger.debug(LOG_SYSTEM, `Loaded indexer endpoint for ${networkId}: ${value}`);
+          }
         } else if (key.startsWith(`${VITE_ENV_PREFIX}FEATURE_FLAG_`)) {
           const flagNameSuffix = key.substring(`${VITE_ENV_PREFIX}FEATURE_FLAG_`.length);
           const flagName = flagNameSuffix.toLowerCase();
@@ -164,6 +172,14 @@ export class AppConfigService {
       for (const networkKey in loadedRpcEndpoints) {
         if (Object.prototype.hasOwnProperty.call(loadedRpcEndpoints, networkKey)) {
           this.config.rpcEndpoints[networkKey] = loadedRpcEndpoints[networkKey];
+        }
+      }
+    }
+    if (Object.keys(loadedIndexerEndpoints).length > 0) {
+      if (!this.config.indexerEndpoints) this.config.indexerEndpoints = {};
+      for (const networkKey in loadedIndexerEndpoints) {
+        if (Object.prototype.hasOwnProperty.call(loadedIndexerEndpoints, networkKey)) {
+          this.config.indexerEndpoints[networkKey] = loadedIndexerEndpoints[networkKey];
         }
       }
     }


### PR DESCRIPTION
## Summary

- Add support for `VITE_APP_CFG_INDEXER_ENDPOINT_{NETWORK_ID}` environment variables to configure indexer endpoints at runtime
- This enables configuring indexer endpoints (which may contain API keys) via `.env.local` files instead of committing secrets to `app.config.json`

## Changes

- Add parsing for `VITE_APP_CFG_INDEXER_ENDPOINT_*` pattern in `loadFromViteEnvironment()`
- Add merging of loaded indexer endpoints into `config.indexerEndpoints`
- Add unit tests for env var parsing and `getIndexerEndpointOverride` getter
- Update "getters warn before initialization" test to include indexer endpoint

## Usage

```bash
# In .env.local (gitignored)
VITE_APP_CFG_INDEXER_ENDPOINT_STELLAR_TESTNET=https://gateway.subquery.network/query/xxx?apikey=YOUR_KEY
```

## Test plan

- [x] Unit tests for `VITE_APP_CFG_INDEXER_ENDPOINT_*` parsing
- [x] Unit tests for `getIndexerEndpointOverride()` getter
- [x] All 228 existing tests pass