### PR TITLE
fix(adapter-stellar): resolve on-chain role enumeration in test environment

### DIFF
--- a/packages/adapter-stellar/src/access-control/onchain-reader.ts
+++ b/packages/adapter-stellar/src/access-control/onchain-reader.ts
@@ -163,7 +163,15 @@ export async function getRoleMemberCount(
       inputs
     );
 
-    return typeof result === 'number' ? result : 0;
+    // Handle both number and string results (formatter may return string for large numbers)
+    if (typeof result === 'number') {
+      return result;
+    }
+    if (typeof result === 'string') {
+      const parsed = parseInt(result, 10);
+      return isNaN(parsed) ? 0 : parsed;
+    }
+    return 0;
   } catch (error) {
     logger.error('getRoleMemberCount', `Failed to get member count for role ${roleId}:`, error);
     return 0;

--- a/packages/adapter-stellar/src/query/handler.ts
+++ b/packages/adapter-stellar/src/query/handler.ts
@@ -3,7 +3,6 @@ import {
   Address,
   BASE_FEE,
   Contract,
-  Keypair,
   nativeToScVal,
   rpc as StellarRpc,
   TransactionBuilder,
@@ -61,9 +60,12 @@ async function createSimulationTransaction(
 ): Promise<TransactionBuilder> {
   try {
     // Create a dummy source account for simulation
-    // We'll use a well-known testnet account for simulation
-    const dummyKeypair = Keypair.random();
-    const sourceAccount = new Account(dummyKeypair.publicKey(), '0');
+    // For simulations, we only need a valid public key - no private key required.
+    // Using a hardcoded test public key avoids Keypair.random() issues in test environments
+    // where @noble/curves crypto may not work correctly.
+    // This is a valid Stellar public key (the "zero" key derived from 32 zero bytes).
+    const SIMULATION_PUBLIC_KEY = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+    const sourceAccount = new Account(SIMULATION_PUBLIC_KEY, '0');
 
     // Create contract instance
     const contract = new Contract(contractAddress);


### PR DESCRIPTION
## Summary
- Use hardcoded simulation public key instead of `Keypair.random()` to avoid `@noble/curves` crypto issues in test environments
- Handle both number and string results from `getRoleMemberCount` RPC calls (formatter may return string for large numbers)
- Add proper timeout handling for indexer availability checks in integration tests
- Fix formatting issues in integration tests

## Test plan
- [x] All 27 integration tests pass with real Soroban RPC calls
- [x] On-chain role enumeration tests successfully fetch live data
- [x] Indexer role discovery works end-to-end (discovers 7 roles, enumerates 12 members)
- [x] Graceful degradation when indexer is unavailable (uses known roles fallback)