### PR TITLE
feat(adapter-stellar): add enriched role assignments with grant timestamps

### DIFF
--- a/packages/types/src/adapters/access-control.ts
+++ b/packages/types/src/adapters/access-control.ts
@@ -55,6 +55,32 @@ export interface RoleAssignment {
 }
 
 /**
+ * Enriched role member with grant metadata
+ * Used when historical data is available via indexer
+ */
+export interface EnrichedRoleMember {
+  /** The member's address */
+  address: string;
+  /** ISO8601 timestamp of when the role was granted (undefined if indexer unavailable) */
+  grantedAt?: string;
+  /** Transaction ID of the grant operation */
+  grantedTxId?: string;
+  /** Block/ledger number of the grant operation */
+  grantedLedger?: number;
+}
+
+/**
+ * Enriched role assignment with detailed member information
+ * Includes grant timestamps when indexer data is available
+ */
+export interface EnrichedRoleAssignment {
+  /** The role identifier */
+  role: RoleIdentifier;
+  /** Array of enriched member information */
+  members: EnrichedRoleMember[];
+}
+
+/**
  * Snapshot of access control state at a point in time
  */
 export interface AccessSnapshot {
@@ -114,6 +140,18 @@ export interface AccessControlService {
    * @returns Promise resolving to array of role assignments
    */
   getCurrentRoles(contractAddress: string): Promise<RoleAssignment[]>;
+
+  /**
+   * Get current role assignments with enriched member information
+   *
+   * Returns role assignments with metadata about when each member was granted
+   * the role. If the indexer is unavailable, gracefully degrades to returning
+   * members without timestamp information.
+   *
+   * @param contractAddress The contract address
+   * @returns Promise resolving to array of enriched role assignments
+   */
+  getCurrentRolesEnriched(contractAddress: string): Promise<EnrichedRoleAssignment[]>;
 
   /**
    * Grant a role to an account


### PR DESCRIPTION
## Summary

- Add `getCurrentRolesEnriched()` method that returns role assignments enriched with metadata about when each member was granted their role
- Combines on-chain state (who has what role) with indexer history (when they got it)
- Graceful degradation when indexer is unavailable - returns data without timestamps instead of failing

## Changes

- **Types**: Add `EnrichedRoleMember` and `EnrichedRoleAssignment` interfaces
- **Indexer Client**: Add `queryLatestGrants()` method for batch querying grant events
- **Service**: Add `getCurrentRolesEnriched()` method with graceful degradation

## Usage

```typescript
const enrichedRoles = await service.getCurrentRolesEnriched(contractAddress);
// Returns:
// [
//   {
//     role: { id: 'admin', label: 'admin' },
//     members: [
//       {
//         address: 'GBZXN7PIR...',
//         grantedAt: '2024-01-15T10:00:00Z',
//         grantedTxId: 'abc123...',
//         grantedLedger: 5000
//       }
//     ]
//   }
// ]
```

## Test plan

- [x] Unit tests for `queryLatestGrants()` (9 tests)
- [x] Unit tests for `getCurrentRolesEnriched()` (8 tests)
- [x] Integration tests with real SubQuery indexer (4 tests)
- [x] All 706 tests passing