### PR TITLE
feat(adapter-stellar): add server-side changeType filtering to getHistory

### DIFF
--- a/packages/adapter-stellar/src/access-control/indexer-client.ts
+++ b/packages/adapter-stellar/src/access-control/indexer-client.ts
@@ -669,17 +669,19 @@ export class StellarIndexerClient {
   private transformIndexerEntries(entries: IndexerHistoryEntry[]): HistoryEntry[] {
     return entries.map((entry) => {
       const role: RoleIdentifier = {
-        id: entry.role || 'OWNER', // Map ownership events to special role or null
+        id: entry.role || 'OWNER', // Map ownership events to special role
       };
 
       // Map SubQuery event types to internal types
-      let changeType: 'GRANTED' | 'REVOKED';
+      let changeType: HistoryChangeType;
       if (entry.type === 'ROLE_GRANTED') {
         changeType = 'GRANTED';
       } else if (entry.type === 'ROLE_REVOKED') {
         changeType = 'REVOKED';
+      } else if (entry.type === 'OWNERSHIP_TRANSFER_COMPLETED') {
+        changeType = 'TRANSFERRED';
       } else {
-        // Treat ownership transfer as a grant for now, or handle differently if HistoryEntry supports it
+        // Default to GRANTED for unknown types (shouldn't happen)
         changeType = 'GRANTED';
       }
 

--- a/packages/adapter-stellar/test/access-control/indexer-client.spec.ts
+++ b/packages/adapter-stellar/test/access-control/indexer-client.spec.ts
@@ -506,7 +506,7 @@ describe('StellarIndexerClient (T031, T033)', () => {
 
       expect(result.items).toHaveLength(1);
       expect(result.items[0].role.id).toBe('OWNER'); // Should map null role to 'OWNER'
-      expect(result.items[0].changeType).toBe('GRANTED'); // Ownership transfer treated as GRANTED
+      expect(result.items[0].changeType).toBe('TRANSFERRED'); // Ownership transfer maps to TRANSFERRED
     });
   });
 

--- a/packages/adapter-stellar/test/access-control/indexer-integration.test.ts
+++ b/packages/adapter-stellar/test/access-control/indexer-integration.test.ts
@@ -526,6 +526,38 @@ describe('StellarIndexerClient - Integration Test with Real Indexer', () => {
       console.log(`  ✅ Filtered ${revokedResult.items.length} REVOKED events (server-side)`);
     }, 15000);
 
+    it('should filter history by changeType TRANSFERRED (server-side)', async () => {
+      if (!indexerAvailable) {
+        return; // Skip test if indexer is not available
+      }
+
+      // First check if there are any TRANSFERRED (ownership) events
+      const allResult = await client.queryHistory(TEST_CONTRACT);
+      const hasTransferredEvents = allResult.items.some((e) => e.changeType === 'TRANSFERRED');
+
+      if (!hasTransferredEvents) {
+        console.log('  ⏭️ No TRANSFERRED events in contract, skipping filter test');
+        return;
+      }
+
+      // Query with changeType filter for TRANSFERRED events only
+      const transferredResult = await client.queryHistory(TEST_CONTRACT, {
+        changeType: 'TRANSFERRED',
+        limit: 20,
+      });
+
+      expect(transferredResult.items.length).toBeGreaterThan(0);
+
+      // Verify ALL returned entries have changeType: 'TRANSFERRED'
+      for (const entry of transferredResult.items) {
+        expect(entry.changeType).toBe('TRANSFERRED');
+      }
+
+      console.log(
+        `  ✅ Filtered ${transferredResult.items.length} TRANSFERRED events (server-side)`
+      );
+    }, 15000);
+
     it('should combine changeType filter with pagination', async () => {
       if (!indexerAvailable) {
         return; // Skip test if indexer is not available

--- a/packages/types/src/adapters/access-control.ts
+++ b/packages/types/src/adapters/access-control.ts
@@ -91,6 +91,11 @@ export interface AccessSnapshot {
 }
 
 /**
+ * Change type for history events (grant, revoke, or ownership transfer)
+ */
+export type HistoryChangeType = 'GRANTED' | 'REVOKED' | 'TRANSFERRED';
+
+/**
  * History entry for role changes (adapter-specific, when history is supported)
  */
 export interface HistoryEntry {
@@ -99,7 +104,7 @@ export interface HistoryEntry {
   /** The account that was granted or revoked */
   account: string;
   /** Type of change */
-  changeType: 'GRANTED' | 'REVOKED';
+  changeType: HistoryChangeType;
   /** Transaction identifier */
   txId: string;
   /** Optional timestamp (ISO8601 format) */
@@ -127,11 +132,6 @@ export interface PaginatedHistoryResult {
   /** Pagination information */
   pageInfo: PageInfo;
 }
-
-/**
- * Change type for filtering history events
- */
-export type HistoryChangeType = 'GRANTED' | 'REVOKED' | 'TRANSFERRED';
 
 /**
  * Options for querying history with pagination


### PR DESCRIPTION
## Summary

- Adds server-side `changeType` filtering to `getHistory()` API, enabling filtering by event type (`GRANTED`, `REVOKED`, `TRANSFERRED`) across paginated results
- Previously, filtering by action type only worked client-side on the current page; users couldn't see filtered results across all pages
- Includes integration tests verifying filter works with pagination and combines correctly with `roleId` and `account` filters

## Changes

**Types Package** (`packages/types/src/adapters/access-control.ts`):
- Added `HistoryChangeType` type: `'GRANTED' | 'REVOKED' | 'TRANSFERRED'`
- Added `changeType` parameter to `HistoryQueryOptions` interface

**Adapter Package** (`packages/adapter-stellar/src/access-control/indexer-client.ts`):
- Added `changeType` to `IndexerHistoryOptions` interface
- Added `mapChangeTypeToGraphQLEnum()` helper to map internal types to GraphQL enum values
- Updated `buildHistoryQuery()` to include type filter when `changeType` is provided

**Tests**:
- Added 5 integration tests for `changeType` filtering (server-side GRANTED/REVOKED, pagination, combined filters)
- Fixed existing unit tests with missing `pageInfo` in mock responses

## Test plan

- [x] Integration tests pass with real indexer endpoint
- [x] All 718 existing unit tests pass
- [x] Filter correctly returns only events matching `changeType`
- [x] Pagination works correctly with `changeType` filter
- [x] Combined filters (`changeType` + `roleId`, `changeType` + `account`) work correctly