### PR TITLE
fix(ui): prevent unknown props from leaking to DOM in CodeEditorField

### DIFF
--- a/packages/ui/src/components/fields/CodeEditorField.tsx
+++ b/packages/ui/src/components/fields/CodeEditorField.tsx
@@ -8,12 +8,16 @@ import { ErrorMessage } from './utils';
 /**
  * CodeEditorField component properties
  */
-export interface CodeEditorFieldProps<TFieldValues extends FieldValues = FieldValues>
-  extends React.ComponentPropsWithoutRef<'div'> {
+export interface CodeEditorFieldProps<TFieldValues extends FieldValues = FieldValues> {
   /**
    * Unique identifier for the field
    */
   id: string;
+
+  /**
+   * Optional CSS class name for the container
+   */
+  className?: string;
 
   /**
    * Field name for form control
@@ -126,7 +130,6 @@ export function CodeEditorField<TFieldValues extends FieldValues = FieldValues>(
   readOnly = false,
   validateCode,
   className,
-  ...props
 }: CodeEditorFieldProps<TFieldValues>): React.ReactElement {
   // Convert height strings to numbers for native props with robust parsing
   function extractPixelValue(val: string | number, fallback: number): number {
@@ -139,7 +142,7 @@ export function CodeEditorField<TFieldValues extends FieldValues = FieldValues>(
   const maxHeightNum = extractPixelValue(maxHeight, 400);
 
   return (
-    <div className={className} {...props}>
+    <div className={className}>
       {label && (
         <label htmlFor={id} className="block text-sm font-medium text-foreground mb-2">
           {label}


### PR DESCRIPTION
## Summary

- Fixes React warning: `React does not recognize the 'contractSchema' prop on a DOM element`
- Remove `extends React.ComponentPropsWithoutRef<'div'>` from CodeEditorField interface
- Stop spreading unknown props to the outer `<div>` element
- Explicitly define `className` as an optional prop instead of relying on div props inheritance

## Problem

The `CodeEditorField` component was extending `React.ComponentPropsWithoutRef<'div'>` and spreading `{...props}` to a native DOM element. When `DynamicFormField` passes props like `contractSchema`, `adapter`, etc. to field components, these were leaking to the DOM and causing React warnings.

## Solution

Make the component self-contained by only accepting and using explicitly defined props. This is more defensive and keeps the UI package app-agnostic - it doesn't need to know about props from other packages.

## Test plan

- [x] TypeScript compilation passes
- [x] No linter errors
- [ ] Verify React warning no longer appears when navigating to contract definition step