### PR TITLE
fix(ui): Consistent styling for SelectField helper text and errors

### DIFF
--- a/packages/ui/src/components/fields/SelectField.tsx
+++ b/packages/ui/src/components/fields/SelectField.tsx
@@ -6,6 +6,7 @@ import { cn } from '@openzeppelin/ui-builder-utils';
 import { Label } from '../ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { BaseFieldProps } from './BaseField';
+import { ErrorMessage } from './utils';
 
 /**
  * Option item for select fields
@@ -170,17 +171,13 @@ export function SelectField<TFieldValues extends FieldValues = FieldValues>({
 
               {/* Display helper text */}
               {helperText && (
-                <div id={descriptionId} data-slot="form-description">
+                <div id={descriptionId} className="text-muted-foreground text-sm">
                   {helperText}
                 </div>
               )}
 
               {/* Display error message */}
-              {error && (
-                <div id={errorId} data-slot="form-message">
-                  {error.message}
-                </div>
-              )}
+              <ErrorMessage error={error} id={errorId} />
             </>
           );
         }}

--- a/packages/ui/src/components/fields/SelectGroupedField.tsx
+++ b/packages/ui/src/components/fields/SelectGroupedField.tsx
@@ -15,6 +15,7 @@ import {
   SelectValue,
 } from '../ui/select';
 import { BaseFieldProps } from './BaseField';
+import { ErrorMessage } from './utils';
 
 /**
  * Option item for select fields with visual indicators
@@ -195,17 +196,13 @@ export function SelectGroupedField<TFieldValues extends FieldValues = FieldValue
 
               {/* Display helper text */}
               {helperText && (
-                <div id={descriptionId} data-slot="form-description">
+                <div id={descriptionId} className="text-muted-foreground text-sm">
                   {helperText}
                 </div>
               )}
 
               {/* Display error message */}
-              {error && (
-                <div id={errorId} data-slot="form-message">
-                  {error.message}
-                </div>
-              )}
+              <ErrorMessage error={error} id={errorId} />
             </>
           );
         }}


### PR DESCRIPTION
## Summary

This PR fixes styling inconsistencies in `SelectField` and `SelectGroupedField` components to match other form field components like `AddressField`.

## Changes

### SelectField.tsx
- Added `text-muted-foreground text-sm` classes to the helperText div (matching `AddressField`)
- Replaced inline error div with the `ErrorMessage` component (matching other fields)

### SelectGroupedField.tsx
- Same fixes applied for consistency

## Before
- helperText: `<div id={descriptionId} data-slot="form-description">`
- error: `<div id={errorId} data-slot="form-message">`

## After
- helperText: `<div id={descriptionId} className="text-muted-foreground text-sm">`
- error: `<ErrorMessage error={error} id={errorId} />`

This ensures consistent visual styling across all form field components.