### PR TITLE
perf(analytics): memoize useBuilderAnalytics return value

### DIFF
--- a/packages/builder/src/hooks/useBuilderAnalytics.ts
+++ b/packages/builder/src/hooks/useBuilderAnalytics.ts
@@ -1,8 +1,12 @@
+import { useMemo } from 'react';
+
 import { useAnalytics } from '@openzeppelin/ui-builder-react-core';
 
 /**
  * UI Builder-specific analytics hook.
  * Wraps the shared useAnalytics hook with builder-specific tracking events.
+ *
+ * Returns a memoized object to ensure stable function references across renders.
  *
  * @example
  * ```tsx
@@ -20,40 +24,43 @@ import { useAnalytics } from '@openzeppelin/ui-builder-react-core';
 export function useBuilderAnalytics() {
   const analytics = useAnalytics();
 
-  return {
-    ...analytics,
+  return useMemo(
+    () => ({
+      ...analytics,
 
-    /**
-     * Track ecosystem selection event.
-     * @param ecosystem - Selected ecosystem (e.g., 'evm', 'solana', 'stellar')
-     */
-    trackEcosystemSelection: (ecosystem: string) => {
-      analytics.trackEvent('ecosystem_selected', { ecosystem });
-    },
+      /**
+       * Track ecosystem selection event.
+       * @param ecosystem - Selected ecosystem (e.g., 'evm', 'solana', 'stellar')
+       */
+      trackEcosystemSelection: (ecosystem: string) => {
+        analytics.trackEvent('ecosystem_selected', { ecosystem });
+      },
 
-    /**
-     * Track export action event.
-     * @param exportType - Type of export (e.g., 'react-vite')
-     */
-    trackExportAction: (exportType: string) => {
-      analytics.trackEvent('export_clicked', { export_type: exportType });
-    },
+      /**
+       * Track export action event.
+       * @param exportType - Type of export (e.g., 'react-vite')
+       */
+      trackExportAction: (exportType: string) => {
+        analytics.trackEvent('export_clicked', { export_type: exportType });
+      },
 
-    /**
-     * Track wizard step progression.
-     * @param stepNumber - Current step number
-     * @param stepName - Name/identifier of the step
-     */
-    trackWizardStep: (stepNumber: number, stepName: string) => {
-      analytics.trackEvent('wizard_step', { step_number: stepNumber, step_name: stepName });
-    },
+      /**
+       * Track wizard step progression.
+       * @param stepNumber - Current step number
+       * @param stepName - Name/identifier of the step
+       */
+      trackWizardStep: (stepNumber: number, stepName: string) => {
+        analytics.trackEvent('wizard_step', { step_number: stepNumber, step_name: stepName });
+      },
 
-    /**
-     * Track sidebar interaction event.
-     * @param action - Action performed (e.g., 'import', 'export')
-     */
-    trackSidebarInteraction: (action: string) => {
-      analytics.trackEvent('sidebar_interaction', { action });
-    },
-  };
+      /**
+       * Track sidebar interaction event.
+       * @param action - Action performed (e.g., 'import', 'export')
+       */
+      trackSidebarInteraction: (action: string) => {
+        analytics.trackEvent('sidebar_interaction', { action });
+      },
+    }),
+    [analytics]
+  );
 }


### PR DESCRIPTION
## Summary
- Wrap `useBuilderAnalytics` return object in `useMemo` to ensure stable function references across renders
- Prevents unnecessary effect re-runs in components that include tracking functions in dependency arrays (e.g., `TrackedRoute`)

## Test plan
- [x] Existing tests pass
- [ ] Verify no performance regression in analytics tracking