### PR TITLE
fix(adapter-stellar): read user-configured indexer from localStorage

### DIFF
--- a/packages/adapter-stellar/src/access-control/service.ts
+++ b/packages/adapter-stellar/src/access-control/service.ts
@@ -1318,6 +1318,22 @@ export class StellarAccessControlService implements AccessControlService {
       return [];
     }
   }
+
+  /**
+   * Disposes of the service and cleans up resources.
+   *
+   * Cleans up the indexer client's subscriptions to prevent memory leaks.
+   * Call this method when the service is no longer needed.
+   *
+   * Note: In typical usage where the service is application-scoped and lives
+   * for the duration of the application, calling dispose is not strictly necessary.
+   * However, it should be called if the service is created/destroyed dynamically
+   * (e.g., in tests or when switching networks).
+   */
+  dispose(): void {
+    this.indexerClient.dispose();
+    logger.debug('StellarAccessControlService.dispose', 'Service disposed');
+  }
 }
 
 /**

--- a/packages/adapter-stellar/test/access-control/admin-two-step.test.ts
+++ b/packages/adapter-stellar/test/access-control/admin-two-step.test.ts
@@ -9,7 +9,26 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { ContractSchema, StellarNetworkConfig } from '@openzeppelin/ui-builder-types';
+import type {
+  ContractFunction,
+  ContractSchema,
+  StellarNetworkConfig,
+} from '@openzeppelin/ui-builder-types';
+
+/**
+ * Helper to create a minimal mock ContractFunction with required properties
+ */
+function mockFn(name: string): ContractFunction {
+  return {
+    id: name,
+    name,
+    displayName: name,
+    type: 'function',
+    modifiesState: false,
+    inputs: [],
+    outputs: [],
+  };
+}
 
 // Mock the Stellar SDK
 vi.mock('@stellar/stellar-sdk', () => ({
@@ -22,7 +41,7 @@ vi.mock('@stellar/stellar-sdk', () => ({
   },
 }));
 
-// Mock the logger
+// Mock the logger and config services
 vi.mock('@openzeppelin/ui-builder-utils', () => ({
   logger: {
     info: vi.fn(),
@@ -32,6 +51,18 @@ vi.mock('@openzeppelin/ui-builder-utils', () => ({
   },
   appConfigService: {
     getIndexerEndpointOverride: vi.fn().mockReturnValue(null),
+  },
+  userNetworkServiceConfigService: {
+    get: vi.fn().mockReturnValue(null),
+    subscribe: vi.fn().mockReturnValue(() => {}),
+  },
+  isValidUrl: (url: string) => {
+    try {
+      new URL(url);
+      return true;
+    } catch {
+      return false;
+    }
   },
   validateSnapshot: vi.fn().mockReturnValue(true),
 }));
@@ -63,18 +94,19 @@ describe('Two-Step Admin Transfer Support', () => {
       );
 
       const contractSchema: ContractSchema = {
+        ecosystem: 'stellar',
         functions: [
           // Required AccessControl functions
-          { name: 'has_role', inputs: [], outputs: [] },
-          { name: 'grant_role', inputs: [], outputs: [] },
-          { name: 'revoke_role', inputs: [], outputs: [] },
+          mockFn('has_role'),
+          mockFn('grant_role'),
+          mockFn('revoke_role'),
           // Optional AccessControl functions including two-step admin
-          { name: 'get_admin', inputs: [], outputs: [] },
-          { name: 'get_role_admin', inputs: [], outputs: [] },
-          { name: 'set_role_admin', inputs: [], outputs: [] },
-          { name: 'transfer_admin_role', inputs: [], outputs: [] },
-          { name: 'accept_admin_transfer', inputs: [], outputs: [] },
-          { name: 'renounce_admin', inputs: [], outputs: [] },
+          mockFn('get_admin'),
+          mockFn('get_role_admin'),
+          mockFn('set_role_admin'),
+          mockFn('transfer_admin_role'),
+          mockFn('accept_admin_transfer'),
+          mockFn('renounce_admin'),
         ],
       };
 
@@ -94,16 +126,17 @@ describe('Two-Step Admin Transfer Support', () => {
       );
 
       const contractSchema: ContractSchema = {
+        ecosystem: 'stellar',
         functions: [
           // Required AccessControl functions
-          { name: 'has_role', inputs: [], outputs: [] },
-          { name: 'grant_role', inputs: [], outputs: [] },
-          { name: 'revoke_role', inputs: [], outputs: [] },
+          mockFn('has_role'),
+          mockFn('grant_role'),
+          mockFn('revoke_role'),
           // Optional AccessControl functions WITHOUT two-step admin
-          { name: 'get_admin', inputs: [], outputs: [] },
-          { name: 'get_role_admin', inputs: [], outputs: [] },
-          { name: 'set_role_admin', inputs: [], outputs: [] },
-          { name: 'renounce_admin', inputs: [], outputs: [] },
+          mockFn('get_admin'),
+          mockFn('get_role_admin'),
+          mockFn('set_role_admin'),
+          mockFn('renounce_admin'),
         ],
       };
 
@@ -119,11 +152,12 @@ describe('Two-Step Admin Transfer Support', () => {
       );
 
       const contractSchema: ContractSchema = {
+        ecosystem: 'stellar',
         functions: [
           // Only Ownable functions
-          { name: 'get_owner', inputs: [], outputs: [] },
-          { name: 'transfer_ownership', inputs: [], outputs: [] },
-          { name: 'accept_ownership', inputs: [], outputs: [] },
+          mockFn('get_owner'),
+          mockFn('transfer_ownership'),
+          mockFn('accept_ownership'),
         ],
       };
 

--- a/packages/adapter-stellar/test/access-control/indexer-client.test.ts
+++ b/packages/adapter-stellar/test/access-control/indexer-client.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for StellarIndexerClient
+ *
+ * Tests user configuration from localStorage, config priority, and cache reset behavior.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { StellarNetworkConfig } from '@openzeppelin/ui-builder-types';
+
+import { createIndexerClient } from '../../src/access-control/indexer-client';
+
+// Mock the utils module
+const mockUserConfigGet = vi.fn();
+const mockUserConfigSubscribe = vi.fn().mockReturnValue(() => {});
+const mockAppConfigGetIndexer = vi.fn();
+
+vi.mock('@openzeppelin/ui-builder-utils', () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  isValidUrl: (url: string) => {
+    try {
+      new URL(url);
+      return (
+        url.startsWith('http://') ||
+        url.startsWith('https://') ||
+        url.startsWith('wss://') ||
+        url.startsWith('ws://')
+      );
+    } catch {
+      return false;
+    }
+  },
+  userNetworkServiceConfigService: {
+    get: (...args: unknown[]) => mockUserConfigGet(...args),
+    subscribe: (...args: unknown[]) => mockUserConfigSubscribe(...args),
+  },
+  appConfigService: {
+    getIndexerEndpointOverride: (...args: unknown[]) => mockAppConfigGetIndexer(...args),
+  },
+}));
+
+describe('StellarIndexerClient - User Configuration', () => {
+  let mockNetworkConfig: StellarNetworkConfig;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockNetworkConfig = {
+      id: 'stellar-testnet',
+      name: 'Stellar Testnet',
+      ecosystem: 'stellar',
+      network: 'stellar',
+      type: 'testnet',
+      isTestnet: true,
+      exportConstName: 'stellarTestnet',
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      explorerUrl: 'https://stellar.expert/explorer/testnet',
+    };
+  });
+
+  describe('getUserIndexerEndpoints', () => {
+    it('should read user config from localStorage via userNetworkServiceConfigService', async () => {
+      const userIndexerUrl = 'https://user-configured-indexer.example.com/graphql';
+      mockUserConfigGet.mockReturnValue({
+        indexerUri: userIndexerUrl,
+      });
+      mockAppConfigGetIndexer.mockReturnValue(undefined);
+
+      const client = createIndexerClient(mockNetworkConfig);
+
+      // Trigger endpoint resolution by calling checkAvailability
+      // The client will try to resolve endpoints
+      await client.checkAvailability().catch(() => {});
+
+      // Verify userNetworkServiceConfigService.get was called with correct params
+      expect(mockUserConfigGet).toHaveBeenCalledWith('stellar-testnet', 'indexer');
+    });
+
+    it('should prioritize user config over AppConfigService', async () => {
+      const userIndexerUrl = 'https://user-configured-indexer.example.com/graphql';
+      const appConfigIndexerUrl = 'https://app-config-indexer.example.com/graphql';
+
+      mockUserConfigGet.mockReturnValue({
+        indexerUri: userIndexerUrl,
+      });
+      mockAppConfigGetIndexer.mockReturnValue(appConfigIndexerUrl);
+
+      const client = createIndexerClient(mockNetworkConfig);
+
+      // Trigger endpoint resolution
+      await client.checkAvailability().catch(() => {});
+
+      // User config should be checked first
+      expect(mockUserConfigGet).toHaveBeenCalledWith('stellar-testnet', 'indexer');
+    });
+
+    it('should fall back to AppConfigService when no user config', async () => {
+      mockUserConfigGet.mockReturnValue(null);
+      mockAppConfigGetIndexer.mockReturnValue('https://app-config-indexer.example.com/graphql');
+
+      const client = createIndexerClient(mockNetworkConfig);
+
+      await client.checkAvailability().catch(() => {});
+
+      expect(mockUserConfigGet).toHaveBeenCalledWith('stellar-testnet', 'indexer');
+      expect(mockAppConfigGetIndexer).toHaveBeenCalledWith('stellar-testnet');
+    });
+
+    it('should fall back to network config when no user or app config', async () => {
+      mockUserConfigGet.mockReturnValue(null);
+      mockAppConfigGetIndexer.mockReturnValue(undefined);
+
+      const configWithIndexer: StellarNetworkConfig = {
+        ...mockNetworkConfig,
+        indexerUri: 'https://network-default-indexer.example.com/graphql',
+      };
+
+      const client = createIndexerClient(configWithIndexer);
+
+      await client.checkAvailability().catch(() => {});
+
+      expect(mockUserConfigGet).toHaveBeenCalledWith('stellar-testnet', 'indexer');
+      expect(mockAppConfigGetIndexer).toHaveBeenCalledWith('stellar-testnet');
+    });
+
+    it('should ignore invalid URLs from user config', async () => {
+      mockUserConfigGet.mockReturnValue({
+        indexerUri: 'not-a-valid-url',
+      });
+      mockAppConfigGetIndexer.mockReturnValue('https://valid-fallback.example.com/graphql');
+
+      const client = createIndexerClient(mockNetworkConfig);
+
+      await client.checkAvailability().catch(() => {});
+
+      // Should have tried user config but fallen back due to invalid URL
+      expect(mockUserConfigGet).toHaveBeenCalledWith('stellar-testnet', 'indexer');
+      expect(mockAppConfigGetIndexer).toHaveBeenCalledWith('stellar-testnet');
+    });
+
+    it('should handle both HTTP and WebSocket endpoints from user config', async () => {
+      mockUserConfigGet.mockReturnValue({
+        indexerUri: 'https://user-http.example.com/graphql',
+        indexerWsUri: 'wss://user-ws.example.com/graphql',
+      });
+
+      const client = createIndexerClient(mockNetworkConfig);
+
+      await client.checkAvailability().catch(() => {});
+
+      expect(mockUserConfigGet).toHaveBeenCalledWith('stellar-testnet', 'indexer');
+    });
+  });
+
+  describe('config change subscription', () => {
+    it('should subscribe to config changes on construction', () => {
+      mockUserConfigGet.mockReturnValue(null);
+
+      createIndexerClient(mockNetworkConfig);
+
+      expect(mockUserConfigSubscribe).toHaveBeenCalledWith(
+        'stellar-testnet',
+        'indexer',
+        expect.any(Function)
+      );
+    });
+
+    it('should reset cache when config changes', async () => {
+      mockUserConfigGet.mockReturnValue({
+        indexerUri: 'https://initial-indexer.example.com/graphql',
+      });
+
+      let configChangeCallback: (() => void) | undefined;
+      mockUserConfigSubscribe.mockImplementation(
+        (_networkId: string, _serviceId: string, callback: () => void) => {
+          configChangeCallback = callback;
+          return () => {};
+        }
+      );
+
+      const client = createIndexerClient(mockNetworkConfig);
+
+      // First call to checkAvailability
+      await client.checkAvailability().catch(() => {});
+      const firstCallCount = mockUserConfigGet.mock.calls.length;
+
+      // Simulate config change
+      if (configChangeCallback) {
+        configChangeCallback();
+      }
+
+      // Second call should re-read config (cache was reset)
+      await client.checkAvailability().catch(() => {});
+      const secondCallCount = mockUserConfigGet.mock.calls.length;
+
+      // Should have called get again after cache reset
+      expect(secondCallCount).toBeGreaterThan(firstCallCount);
+    });
+  });
+
+  describe('dispose', () => {
+    it('should unsubscribe from config changes when disposed', () => {
+      const unsubscribeMock = vi.fn();
+      mockUserConfigSubscribe.mockReturnValue(unsubscribeMock);
+
+      const client = createIndexerClient(mockNetworkConfig);
+      client.dispose();
+
+      expect(unsubscribeMock).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/adapter-stellar/test/access-control/ownable-two-step.test.ts
+++ b/packages/adapter-stellar/test/access-control/ownable-two-step.test.ts
@@ -37,6 +37,18 @@ vi.mock('@openzeppelin/ui-builder-utils', () => ({
   appConfigService: {
     getIndexerEndpointOverride: vi.fn().mockReturnValue(null),
   },
+  userNetworkServiceConfigService: {
+    get: vi.fn().mockReturnValue(null),
+    subscribe: vi.fn().mockReturnValue(() => {}),
+  },
+  isValidUrl: (url: string) => {
+    try {
+      new URL(url);
+      return true;
+    } catch {
+      return false;
+    }
+  },
 }));
 
 describe('Two-Step Ownable Support', () => {


### PR DESCRIPTION
## Summary

- **Bug fix**: The `StellarIndexerClient` was ignoring user-configured indexer endpoints set via the NetworkSettingsDialog UI
- User settings saved to localStorage via `UserNetworkServiceConfigService` were not being read by the indexer client
- Updated endpoint resolution priority to check user config first (aligning with EVM adapter pattern)

## Changes

1. Added `getUserIndexerEndpoints()` helper function to extract user config from localStorage
2. Updated `resolveIndexerEndpoints()` priority order:
   - Priority 1: User-configured (localStorage) ← **NEW**
   - Priority 2: AppConfigService (env/JSON)
   - Priority 3: Network defaults
   - Priority 4: None
3. Added subscription to config changes to reset cache when user updates settings
4. Added `dispose()` method for cleanup
5. Added missing `UNKNOWN` to `mapChangeTypeToGraphQLEnum` mapping

## Context

This bug was discovered when testing the Role Manager app - users could configure the indexer URL via the settings dialog, but requests were still going to the default (or no) endpoint.

The fix follows the same pattern already established in the EVM adapter's `rpc.ts` which correctly reads from `UserNetworkServiceConfigService` as highest priority.

## Test plan

- [ ] Verify indexer config saved via NetworkSettingsDialog is used by StellarIndexerClient
- [ ] Verify changing config via UI triggers cache reset and new endpoint is used
- [ ] Verify fallback to AppConfigService and network defaults still works when no user config