### PR TITLE
chore(changeset): add changeset for stellar user indexer config fix

### DIFF
--- a/.changeset/stellar-user-indexer-config.md
+++ b/.changeset/stellar-user-indexer-config.md
@@ -1,0 +1,14 @@
+---
+'@openzeppelin/ui-builder-adapter-stellar': patch
+---
+
+Fix: Read user-configured indexer endpoints from localStorage
+
+The StellarIndexerClient now correctly reads user-configured indexer endpoints from UserNetworkServiceConfigService (localStorage). Previously, user settings saved via the NetworkSettingsDialog were ignored.
+
+Changes:
+
+- Add user-configured indexer as highest priority in endpoint resolution
+- Add URL validation for user-configured endpoints
+- Subscribe to config changes to reset cache when user updates settings
+- Add dispose() method for cleanup


### PR DESCRIPTION
## Summary

Adds a changeset for the fix merged in PR #282.

This is a **patch** release for `@openzeppelin/ui-builder-adapter-stellar` that:
- Fixes user-configured indexer endpoints being ignored
- Adds URL validation for user config
- Adds proper cleanup with dispose() method