### PR TITLE
test(adapter-stellar): update indexer integration tests for testnet reset

### DIFF
--- a/packages/adapter-stellar/test/access-control/indexer-integration.test.ts
+++ b/packages/adapter-stellar/test/access-control/indexer-integration.test.ts
@@ -1976,12 +1976,12 @@ describe('StellarIndexerClient - Admin Transfer Integration Tests', () => {
       // Try both contracts to find admin transfer events
       const contracts = [TEST_CONTRACT, TEST_CONTRACT_2];
       let targetContract: string | null = null;
-      let adminInitiatedEvents: typeof history.items = [];
-      let adminCompletedEvents: typeof history.items = [];
       let history: Awaited<ReturnType<typeof client.queryHistory>> = {
         items: [],
         pageInfo: { hasNextPage: false },
       };
+      let adminInitiatedEvents: typeof history.items = [];
+      let adminCompletedEvents: typeof history.items = [];
 
       for (const contract of contracts) {
         history = await client.queryHistory(contract);
@@ -2067,12 +2067,12 @@ describe('StellarIndexerClient - Admin Transfer Integration Tests', () => {
       // Try both contracts to find ownership transfer events
       const contracts = [TEST_CONTRACT, TEST_CONTRACT_2];
       let targetContract: string | null = null;
-      let ownershipStartedEvents: typeof history.items = [];
-      let ownershipCompletedEvents: typeof history.items = [];
       let history: Awaited<ReturnType<typeof client.queryHistory>> = {
         items: [],
         pageInfo: { hasNextPage: false },
       };
+      let ownershipStartedEvents: typeof history.items = [];
+      let ownershipCompletedEvents: typeof history.items = [];
 
       for (const contract of contracts) {
         history = await client.queryHistory(contract);


### PR DESCRIPTION
## Summary

Updates the Stellar access control indexer integration tests to work with the new contracts deployed after the Stellar testnet reset.

- Update test contract addresses to new deployments
- Make event-type filtering tests more adaptive (search across available contracts)
- Fix pagination test to handle contracts with more events (increased maxPages from 20 to 30)
- Update timestamp filtering to dynamically discover timestamps from actual data
- Add 'minter' to fallback roles for when indexer is unavailable

## Test plan

- [x] All 63 integration tests pass with live indexer
- [x] Tests gracefully skip when indexer unavailable
- [x] On-chain tests work with new contracts
- [x] No sensitive data (API keys, CIDs) exposed in code