### PR TITLE
feat(adapter-stellar): add default indexer URL for testnet

### DIFF
--- a/.changeset/stellar-testnet-indexer-url.md
+++ b/.changeset/stellar-testnet-indexer-url.md
@@ -1,0 +1,7 @@
+---
+'@openzeppelin/ui-builder-adapter-stellar': patch
+---
+
+Add default indexer URL for Stellar testnet
+
+Configure the SubQuery GraphQL indexer endpoint as the default indexerUri for Stellar testnet network configuration. This enables access control history features out-of-the-box for testnet users.

--- a/packages/adapter-stellar/src/networks/testnet.ts
+++ b/packages/adapter-stellar/src/networks/testnet.ts
@@ -16,5 +16,5 @@ export const stellarTestnet: StellarNetworkConfig = {
   networkPassphrase: 'Test SDF Network ; September 2015',
   explorerUrl: 'https://stellar.expert/explorer/testnet',
   iconComponent: NetworkStellar,
-  // indexerUri and indexerWsUri will be added here when stable testnet indexer endpoints are available
+  indexerUri: 'https://openzepplin-stellar-testnet.graphql.subquery.network',
 };


### PR DESCRIPTION
## Summary

- Add the SubQuery GraphQL indexer endpoint as the default `indexerUri` for Stellar testnet network configuration
- Enables access control history features out-of-the-box for testnet users

## Test plan

- [ ] Verify the Stellar testnet adapter uses the new indexer URL by default
- [ ] Test access control history queries work against the configured endpoint