### PR TITLE
feat(adapter-stellar): add default indexer URL for mainnet

### DIFF
--- a/.changeset/stellar-mainnet-indexer-url.md
+++ b/.changeset/stellar-mainnet-indexer-url.md
@@ -1,0 +1,7 @@
+---
+'@openzeppelin/ui-builder-adapter-stellar': patch
+---
+
+Add default indexer URL for Stellar mainnet
+
+Configure the SubQuery GraphQL indexer endpoint as the default indexerUri for Stellar mainnet (public) network configuration. This enables access control history features out-of-the-box for mainnet users.

--- a/packages/adapter-stellar/src/networks/mainnet.ts
+++ b/packages/adapter-stellar/src/networks/mainnet.ts
@@ -16,5 +16,5 @@ export const stellarPublic: StellarNetworkConfig = {
   networkPassphrase: 'Public Global Stellar Network ; September 2015',
   explorerUrl: 'https://stellar.expert/explorer/public',
   iconComponent: NetworkStellar,
-  // indexerUri and indexerWsUri will be added here when stable mainnet indexer endpoints are available
+  indexerUri: 'https://openzeppelin-stellar-mainnet.graphql.subquery.network/',
 };


### PR DESCRIPTION
## Summary

- Add the SubQuery GraphQL indexer endpoint as the default `indexerUri` for Stellar mainnet (public) network configuration
- Enables access control history features out-of-the-box for mainnet users

## Test plan

- [ ] Verify the Stellar mainnet adapter uses the new indexer URL by default
- [ ] Test access control history queries work against the configured endpoint