### PR TITLE
fix(builder): add explicit source() path for consistent Docker builds

### DIFF
--- a/packages/builder/src/index.css
+++ b/packages/builder/src/index.css
@@ -4,19 +4,18 @@
 /* 
   Import Tailwind directives.
   Tailwind v4 uses automatic content detection for the local project.
-  For npm packages that contain Tailwind classes, we use the @source directive.
+  The source() function sets the base path for scanning - we use the monorepo root.
+  This ensures consistent path resolution in both local dev and Docker builds.
 */
-@import 'tailwindcss';
+@import 'tailwindcss' source('../../../');
 
 /*
   Tell Tailwind to scan @openzeppelin npm packages for class names.
   These packages are installed in node_modules and contain compiled JS files
   with Tailwind classes that need to be included in the final CSS.
   
-  Path from packages/builder/src/index.css:
-  - ../ = packages/builder/
-  - ../../ = packages/
-  - ../../../ = monorepo root (where node_modules lives)
+  Note: node_modules is ignored by default (gitignore patterns), so we must
+  explicitly register it with @source. Path is relative to the stylesheet.
 */
 @source "../../../node_modules/@openzeppelin";
 


### PR DESCRIPTION
## Summary

Fix missing responsive Tailwind CSS classes (xl:hidden, xl:flex, etc.) in production/staging Docker builds.

## Problem

After migrating UI packages to npm, the sidebar layout was broken on staging because Tailwind wasn't generating responsive classes from the `@openzeppelin` npm packages. The `@source` directive was correctly pointing to node_modules, but path resolution differed between local development and Docker builds.

## Solution

Add explicit `source()` function to set the Tailwind base path to the monorepo root:

```css
@import 'tailwindcss' source('../../../');
```

This ensures consistent path resolution in both local dev and Docker builds, allowing the `@source` directive to correctly scan npm packages for class names.

## Testing

- Verified locally that build output CSS contains `xl:block`, `xl:flex`, `xl:flex-col`, `xl:hidden` classes
- Build succeeds without errors
