### PR TITLE
fix(builder): explicitly list npm packages for Tailwind scanning

### DIFF
--- a/packages/builder/src/index.css
+++ b/packages/builder/src/index.css
@@ -15,9 +15,12 @@
   with Tailwind classes that need to be included in the final CSS.
   
   Note: node_modules is ignored by default (gitignore patterns), so we must
-  explicitly register it with @source. Path is relative to the stylesheet.
+  explicitly register it with @source. We scan the top-level @openzeppelin
+  directory which contains symlinks that Vite/esbuild resolves during build.
 */
-@source "../../../node_modules/@openzeppelin";
+@source "../../../node_modules/@openzeppelin/ui-components";
+@source "../../../node_modules/@openzeppelin/ui-renderer";
+@source "../../../node_modules/@openzeppelin/ui-react";
 
 /*
   Import global theme variables and base styles from the @openzeppelin/ui-styles package.


### PR DESCRIPTION
## Summary

Fix missing responsive Tailwind CSS classes (`xl:hidden`, `xl:flex`, `xl:block`, `xl:flex-col`) in production builds after the UI kit extraction to npm packages.

## Problem

After migrating UI packages to npm, the sidebar layout was broken on staging because Tailwind wasn't generating responsive classes. The root cause:

1. pnpm installs packages as symlinks: `node_modules/@openzeppelin/ui-components` → `.pnpm/@openzeppelin+ui-components@1.0.1.../`
2. The `@source "../../../node_modules/@openzeppelin"` directive scanned a directory containing symlinks
3. Tailwind v4 doesn't properly follow symlinks when scanning for class names
4. Responsive classes from npm packages were missed during the build

## Solution

Explicitly list each npm package that contains Tailwind classes:

```css
@source "../../../node_modules/@openzeppelin/ui-components";
@source "../../../node_modules/@openzeppelin/ui-renderer";
@source "../../../node_modules/@openzeppelin/ui-react";
```

When specifying a path directly to a symlink (rather than its parent directory), the filesystem resolver follows it to the actual location containing the source files.

## Testing

- Verified locally that production build CSS now contains `xl:block`, `xl:flex`, `xl:flex-col`, `xl:hidden` classes
- Tested sidebar layout at 1400px width - displays correctly
