### PR TITLE
fix(ci): update ECS task definition with new image before deployment

### DIFF
--- a/.github/workflows/docker-prod.yaml
+++ b/.github/workflows/docker-prod.yaml
@@ -152,10 +152,10 @@ jobs:
       - name: Update task definition and deploy
         run: |
           set -e
-          
+
           NEW_IMAGE="${REGISTRY}/contracts-ui-builder-prod:${{ github.sha }}"
           echo "Target image: $NEW_IMAGE"
-          
+
           # Get the current task definition ARN from the service
           echo "Getting current task definition..."
           TASK_DEF_ARN=$(aws ecs describe-services \
@@ -164,30 +164,48 @@ jobs:
             --region $AWS_REGION \
             --query 'services[0].taskDefinition' \
             --output text)
+
+          # Validate TASK_DEF_ARN
+          if [ -z "$TASK_DEF_ARN" ] || [ "$TASK_DEF_ARN" = "None" ] || [ "$TASK_DEF_ARN" = "null" ]; then
+            echo "ERROR: Failed to retrieve task definition ARN from service '$ECS_SERVICE'"
+            echo "Verify the ECS cluster and service names are correct"
+            exit 1
+          fi
           echo "Current task definition: $TASK_DEF_ARN"
-          
+
           # Get the full task definition
-          aws ecs describe-task-definition \
-            --task-definition $TASK_DEF_ARN \
+          echo "Fetching task definition details..."
+          if ! aws ecs describe-task-definition \
+            --task-definition "$TASK_DEF_ARN" \
             --region $AWS_REGION \
-            --query 'taskDefinition' > task-definition.json
-          
+            --query 'taskDefinition' > task-definition.json; then
+            echo "ERROR: Failed to describe task definition '$TASK_DEF_ARN'"
+            exit 1
+          fi
+
+          # Validate task definition JSON
+          if ! jq empty task-definition.json 2>/dev/null; then
+            echo "ERROR: Invalid JSON in task definition"
+            cat task-definition.json
+            exit 1
+          fi
+
           # Verify container name exists
           CONTAINER_EXISTS=$(jq --arg CONTAINER "$CONTAINER_NAME" '.containerDefinitions | map(select(.name == $CONTAINER)) | length' task-definition.json)
-          if [ "$CONTAINER_EXISTS" -eq "0" ]; then
+          if [ "$CONTAINER_EXISTS" -eq 0 ]; then
             echo "ERROR: Container '$CONTAINER_NAME' not found in task definition"
             echo "Available containers:"
             jq '.containerDefinitions[].name' task-definition.json
             exit 1
           fi
-          
+
           # Update the image and remove read-only fields
           echo "Updating task definition with new image..."
           jq --arg IMAGE "$NEW_IMAGE" --arg CONTAINER "$CONTAINER_NAME" '
             .containerDefinitions |= map(if .name == $CONTAINER then .image = $IMAGE else . end) |
             del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)
           ' task-definition.json > new-task-definition.json
-          
+
           # Register the new task definition
           echo "Registering new task definition..."
           NEW_TASK_DEF_ARN=$(aws ecs register-task-definition \
@@ -195,15 +213,21 @@ jobs:
             --region $AWS_REGION \
             --query 'taskDefinition.taskDefinitionArn' \
             --output text)
+
+          # Validate NEW_TASK_DEF_ARN
+          if [ -z "$NEW_TASK_DEF_ARN" ] || [ "$NEW_TASK_DEF_ARN" = "None" ] || [ "$NEW_TASK_DEF_ARN" = "null" ]; then
+            echo "ERROR: Failed to register new task definition"
+            exit 1
+          fi
           echo "Registered new task definition: $NEW_TASK_DEF_ARN"
-          
+
           # Deploy the new task definition
           echo "Deploying to ECS..."
           aws ecs update-service \
             --cluster $ECS_CLUSTER \
             --service $ECS_SERVICE \
-            --task-definition $NEW_TASK_DEF_ARN \
+            --task-definition "$NEW_TASK_DEF_ARN" \
             --force-new-deployment \
             --region $AWS_REGION
-          
+
           echo "Deployment initiated successfully!"

--- a/.github/workflows/docker-stg.yaml
+++ b/.github/workflows/docker-stg.yaml
@@ -275,17 +275,35 @@ jobs:
             --region $AWS_REGION \
             --query 'services[0].taskDefinition' \
             --output text)
+
+          # Validate TASK_DEF_ARN
+          if [ -z "$TASK_DEF_ARN" ] || [ "$TASK_DEF_ARN" = "None" ] || [ "$TASK_DEF_ARN" = "null" ]; then
+            echo "ERROR: Failed to retrieve task definition ARN from service '$ECS_SERVICE'"
+            echo "Verify the ECS cluster and service names are correct"
+            exit 1
+          fi
           echo "Current task definition: $TASK_DEF_ARN"
 
           # Get the full task definition
-          aws ecs describe-task-definition \
-            --task-definition $TASK_DEF_ARN \
+          echo "Fetching task definition details..."
+          if ! aws ecs describe-task-definition \
+            --task-definition "$TASK_DEF_ARN" \
             --region $AWS_REGION \
-            --query 'taskDefinition' > task-definition.json
+            --query 'taskDefinition' > task-definition.json; then
+            echo "ERROR: Failed to describe task definition '$TASK_DEF_ARN'"
+            exit 1
+          fi
+
+          # Validate task definition JSON
+          if ! jq empty task-definition.json 2>/dev/null; then
+            echo "ERROR: Invalid JSON in task definition"
+            cat task-definition.json
+            exit 1
+          fi
 
           # Verify container name exists
           CONTAINER_EXISTS=$(jq --arg CONTAINER "$CONTAINER_NAME" '.containerDefinitions | map(select(.name == $CONTAINER)) | length' task-definition.json)
-          if [ "$CONTAINER_EXISTS" -eq "0" ]; then
+          if [ "$CONTAINER_EXISTS" -eq 0 ]; then
             echo "ERROR: Container '$CONTAINER_NAME' not found in task definition"
             echo "Available containers:"
             jq '.containerDefinitions[].name' task-definition.json
@@ -306,6 +324,12 @@ jobs:
             --region $AWS_REGION \
             --query 'taskDefinition.taskDefinitionArn' \
             --output text)
+
+          # Validate NEW_TASK_DEF_ARN
+          if [ -z "$NEW_TASK_DEF_ARN" ] || [ "$NEW_TASK_DEF_ARN" = "None" ] || [ "$NEW_TASK_DEF_ARN" = "null" ]; then
+            echo "ERROR: Failed to register new task definition"
+            exit 1
+          fi
           echo "Registered new task definition: $NEW_TASK_DEF_ARN"
 
           # Deploy the new task definition
@@ -313,7 +337,7 @@ jobs:
           aws ecs update-service \
             --cluster $ECS_CLUSTER \
             --service $ECS_SERVICE \
-            --task-definition $NEW_TASK_DEF_ARN \
+            --task-definition "$NEW_TASK_DEF_ARN" \
             --force-new-deployment \
             --region $AWS_REGION
 


### PR DESCRIPTION
## Summary

Fix ECS deployments to actually deploy new Docker images instead of reusing old ones.

## Problem

The staging deployment has been showing old CSS styling for hours despite multiple successful builds. Investigation revealed:

1. The workflow only runs `aws ecs update-service --force-new-deployment`
2. This tells ECS to restart tasks using the **current task definition**
3. The task definition has a **pinned image tag** (old commit SHA), not `:latest`
4. So ECS keeps pulling the same old image on every deployment

## Solution

Update the deploy job to:
1. Get the current task definition from the ECS service
2. Update it with the new image (using the commit SHA tag)
3. Register a new task definition revision
4. Deploy the service with the new task definition

This ensures each deployment uses the freshly built Docker image from that specific commit.

## Changes

- Updated `docker-stg.yaml` deploy job with proper task definition update flow
- Updated `docker-prod.yaml` with the same fix

## Testing

After merging, trigger the staging workflow to verify the new deployment properly updates the Docker image.
