### PR TITLE
fix(ci): harden workflows against injection

### DIFF
--- a/.github/actions/auth-token/action.yml
+++ b/.github/actions/auth-token/action.yml
@@ -1,0 +1,62 @@
+---
+name: Resolve Authentication Token
+description: |
+  Selects between a GitHub App token and the default GITHUB_TOKEN.
+  Uses the app token when credentials are available and the workflow
+  is not triggered from a fork.
+
+inputs:
+  app-id:
+    description: GitHub App ID
+    required: false
+    default: ''
+  private-key:
+    description: GitHub App private key
+    required: false
+    default: ''
+  is-fork:
+    description: Whether the PR is from a fork
+    required: false
+    default: 'false'
+
+outputs:
+  token:
+    description: The resolved authentication token
+    value: ${{ steps.select.outputs.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check if app creds exist
+      id: has-app
+      shell: bash
+      env:
+        IS_FORK: ${{ inputs.is-fork }}
+        APP_ID: ${{ inputs.app-id }}
+        PRIVATE_KEY: ${{ inputs.private-key }}
+      run: |
+        present=true
+        if [ "$IS_FORK" = "true" ]; then present=false; fi
+        if [ -z "$APP_ID" ] || [ -z "$PRIVATE_KEY" ]; then present=false; fi
+        echo "present=$present" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/create-github-app-token@af35edadc00be37caa72ed9f3e6d5f7801bfdf09 # v1.11.7
+      id: gh-app-token
+      if: steps.has-app.outputs.present == 'true'
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+
+    - name: Select token
+      id: select
+      shell: bash
+      env:
+        HAS_APP: ${{ steps.has-app.outputs.present }}
+        APP_TOKEN: ${{ steps.gh-app-token.outputs.token }}
+        FALLBACK_TOKEN: ${{ github.token }}
+      run: |
+        if [ "$HAS_APP" = "true" ]; then
+          echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+        else
+          echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -6,6 +6,10 @@ description: |
 inputs:
   token:
     required: true
+  fetch-depth:
+    description: Number of commits to fetch (0 for full history)
+    required: false
+    default: '1'
 
 runs:
   using: composite
@@ -14,13 +18,14 @@ runs:
       with:
         token: ${{ inputs.token }}
         persist-credentials: true
+        fetch-depth: ${{ inputs.fetch-depth }}
 
-    - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+    - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       with:
         run_install: false
 
     - name: Use node@22
-      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 22.18.0
         cache: 'pnpm'

--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -10,6 +10,10 @@ on:
       - develop
       - "release/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -25,32 +29,16 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check if app creds exist (base repo only)
-        id: has-app
-        run: |
-          present=true
-          if [ "${{ github.event.pull_request.head.repo.fork || false }}" = "true" ]; then present=false; fi
-          if [ -z "${{ vars.GH_APP_ID }}" ] || [ -z "${{ secrets.GH_APP_PRIVATE_KEY }}" ]; then present=false; fi
-          echo "present=$present" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/create-github-app-token@af35edadc00be37caa72ed9f3e6d5f7801bfdf09 # v1.11.7
-        id: gh-app-token
-        if: steps.has-app.outputs.present == 'true'
+      - name: Resolve authentication token
+        id: auth
+        uses: ./.github/actions/auth-token
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
-      - name: Select token
-        id: auth
-        run: |
-          if [ "${{ steps.has-app.outputs.present }}" = "true" ]; then
-            echo "token=${{ steps.gh-app-token.outputs.token }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "token=${{ github.token }}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+          is-fork: ${{ github.event.pull_request.head.repo.fork || false }}
 
       - name: Prepare pre-requisites
         uses: ./.github/actions/prepare
@@ -58,8 +46,10 @@ jobs:
           token: ${{ steps.auth.outputs.token }}
 
       - name: Configure npm authentication for npm registry
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -18,42 +22,22 @@ jobs:
     permissions:
       contents: read
 
-    strategy:
-      matrix:
-        node-version: [22.x]
-
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
 
-      - name: Check if app creds exist (base repo only)
-        id: has-app
-        run: |
-          present=true
-          if [ "${{ github.event.pull_request.head.repo.fork || false }}" = "true" ]; then present=false; fi
-          if [ -z "${{ vars.GH_APP_ID }}" ] || [ -z "${{ secrets.GH_APP_PRIVATE_KEY }}" ]; then present=false; fi
-          echo "present=$present" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/create-github-app-token@af35edadc00be37caa72ed9f3e6d5f7801bfdf09 # v1.11.7
-        id: gh-app-token
-        if: steps.has-app.outputs.present == 'true'
+      - name: Resolve authentication token
+        id: auth
+        uses: ./.github/actions/auth-token
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
-      - name: Select token
-        id: auth
-        run: |
-          if [ "${{ steps.has-app.outputs.present }}" = "true" ]; then
-            echo "token=${{ steps.gh-app-token.outputs.token }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "token=${{ github.token }}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+          is-fork: ${{ github.event.pull_request.head.repo.fork || false }}
 
       - name: Prepare pre-requisites
         uses: ./.github/actions/prepare
@@ -61,8 +45,10 @@ jobs:
           token: ${{ steps.auth.outputs.token }}
 
       - name: Configure npm authentication for npm registry
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 
       - name: Install dependencies
         run: pnpm install
@@ -77,5 +63,3 @@ jobs:
 
       - name: Test
         run: pnpm test
-        # It's okay if no tests exist yet
-        continue-on-error: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -23,32 +27,16 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check if app creds exist (base repo only)
-        id: has-app
-        run: |
-          present=true
-          if [ "${{ github.event.pull_request.head.repo.fork || false }}" = "true" ]; then present=false; fi
-          if [ -z "${{ vars.GH_APP_ID }}" ] || [ -z "${{ secrets.GH_APP_PRIVATE_KEY }}" ]; then present=false; fi
-          echo "present=$present" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/create-github-app-token@af35edadc00be37caa72ed9f3e6d5f7801bfdf09 # v1.11.7
-        id: gh-app-token
-        if: steps.has-app.outputs.present == 'true'
+      - name: Resolve authentication token
+        id: auth
+        uses: ./.github/actions/auth-token
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
-      - name: Select token
-        id: auth
-        run: |
-          if [ "${{ steps.has-app.outputs.present }}" = "true" ]; then
-            echo "token=${{ steps.gh-app-token.outputs.token }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "token=${{ github.token }}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+          is-fork: ${{ github.event.pull_request.head.repo.fork || false }}
 
       - name: Prepare pre-requisites
         uses: ./.github/actions/prepare
@@ -56,8 +44,10 @@ jobs:
           token: ${{ steps.auth.outputs.token }}
 
       - name: Configure npm authentication for npm registry
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -22,32 +22,15 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check if app creds exist (base repo only)
-        id: has-app
-        run: |
-          present=true
-          if [ "${{ github.event.pull_request.head.repo.fork || false }}" = "true" ]; then present=false; fi
-          if [ -z "${{ vars.GH_APP_ID }}" ] || [ -z "${{ secrets.GH_APP_PRIVATE_KEY }}" ]; then present=false; fi
-          echo "present=$present" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/create-github-app-token@af35edadc00be37caa72ed9f3e6d5f7801bfdf09 # v1.11.7
-        id: gh-app-token
-        if: steps.has-app.outputs.present == 'true'
+      - name: Resolve authentication token
+        id: auth
+        uses: ./.github/actions/auth-token
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
-      - name: Select token
-        id: auth
-        run: |
-          if [ "${{ steps.has-app.outputs.present }}" = "true" ]; then
-            echo "token=${{ steps.gh-app-token.outputs.token }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "token=${{ github.token }}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare pre-requisites
         uses: ./.github/actions/prepare
@@ -55,8 +38,10 @@ jobs:
           token: ${{ steps.auth.outputs.token }}
 
       - name: Configure npm authentication for npm registry
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/docker-prod.yaml
+++ b/.github/workflows/docker-prod.yaml
@@ -9,7 +9,7 @@ on:
 # Prevent multiple production deployments from running simultaneously
 concurrency:
   group: production-deployment
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -30,7 +30,7 @@ jobs:
       ROLE_TO_ASSUME: 'arn:aws:iam::${{ secrets.RESEARCH_ACCOUNT_ID }}:role/GithubOIDCResearchAccountRole'
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
 
@@ -50,6 +50,7 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           token: ${{ steps.gh-app-token.outputs.token }}
+          fetch-depth: '0'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
@@ -57,7 +58,7 @@ jobs:
           platforms: 'arm64'
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Set up AWS credentials via OIDC and role chaining
         uses: ./.github/actions/oidc
@@ -136,7 +137,7 @@ jobs:
       id-token: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
 
@@ -151,4 +152,4 @@ jobs:
 
       - name: AWS ECS force new deployment
         run: |
-          aws ecs update-service --cluster $ECS_CLUSTER --service $ECS_SERVICE --force-new-deployment --region $AWS_REGION
+          aws ecs update-service --cluster "$ECS_CLUSTER" --service "$ECS_SERVICE" --force-new-deployment --region "$AWS_REGION"

--- a/.github/workflows/docker-stg.yaml
+++ b/.github/workflows/docker-stg.yaml
@@ -47,7 +47,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
 
@@ -67,10 +67,13 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           token: ${{ steps.gh-app-token.outputs.token }}
+          fetch-depth: '0'
 
       - name: Configure npm authentication for npm registry
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 
       - name: Install dependencies
         run: pnpm install
@@ -85,10 +88,10 @@ jobs:
         run: |
           # Check if there are any pending changesets to create snapshots from
           if [ -z "$(find .changeset -name '*.md' -not -name 'README.md' -not -name 'config.json')" ]; then
-            echo "has_changesets=false" >> $GITHUB_OUTPUT
+            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
             echo "⚠️  No pending changesets found. Skipping RC publishing to prevent stable version pollution."
           else
-            echo "has_changesets=true" >> $GITHUB_OUTPUT
+            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
             echo "✅ Pending changesets found. Proceeding with RC snapshot creation."
           fi
 
@@ -143,6 +146,7 @@ jobs:
 
   build-and-push:
     runs-on: ubuntu-latest
+    needs: publish-rc
     permissions:
       id-token: write
       contents: read
@@ -155,7 +159,7 @@ jobs:
       ROLE_TO_ASSUME: 'arn:aws:iam::${{ secrets.RESEARCH_ACCOUNT_ID }}:role/GithubOIDCResearchAccountRole'
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
 
@@ -168,7 +172,7 @@ jobs:
           platforms: 'arm64'
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Set up AWS credentials via OIDC and role chaining
         uses: ./.github/actions/oidc
@@ -247,7 +251,7 @@ jobs:
       id-token: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
 
@@ -262,4 +266,4 @@ jobs:
 
       - name: AWS ECS force new deployment
         run: |
-          aws ecs update-service --cluster $ECS_CLUSTER --service $ECS_SERVICE --force-new-deployment --region $AWS_REGION
+          aws ecs update-service --cluster "$ECS_CLUSTER" --service "$ECS_SERVICE" --force-new-deployment --region "$AWS_REGION"

--- a/.github/workflows/export-testing.yml
+++ b/.github/workflows/export-testing.yml
@@ -13,6 +13,10 @@ on:
     paths:
       - "apps/builder/src/export/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -23,42 +27,22 @@ jobs:
     permissions:
       contents: read
 
-    strategy:
-      matrix:
-        node-version: [22.x]
-
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
 
-      - name: Check if app creds exist (base repo only)
-        id: has-app
-        run: |
-          present=true
-          if [ "${{ github.event.pull_request.head.repo.fork || false }}" = "true" ]; then present=false; fi
-          if [ -z "${{ vars.GH_APP_ID }}" ] || [ -z "${{ secrets.GH_APP_PRIVATE_KEY }}" ]; then present=false; fi
-          echo "present=$present" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/create-github-app-token@af35edadc00be37caa72ed9f3e6d5f7801bfdf09 # v1.11.7
-        id: gh-app-token
-        if: steps.has-app.outputs.present == 'true'
+      - name: Resolve authentication token
+        id: auth
+        uses: ./.github/actions/auth-token
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
-      - name: Select token
-        id: auth
-        run: |
-          if [ "${{ steps.has-app.outputs.present }}" = "true" ]; then
-            echo "token=${{ steps.gh-app-token.outputs.token }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "token=${{ github.token }}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+          is-fork: ${{ github.event.pull_request.head.repo.fork || false }}
 
       - name: Prepare pre-requisites
         uses: ./.github/actions/prepare
@@ -66,32 +50,29 @@ jobs:
           token: ${{ steps.auth.outputs.token }}
 
       - name: Configure npm authentication for npm registry
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 
       - name: Install dependencies
         run: pnpm install
 
-      # Add this build step to ensure all workspace packages are built before testing
       - name: Build all packages
         run: pnpm -r build
         env:
           NODE_OPTIONS: "--max-old-space-size=8192"
 
-      # Run only export-related tests
       - name: Run export tests
         run: pnpm --filter @openzeppelin/ui-builder-app test src/export/__tests__/
 
-      # Create test-results directory
       - name: Create test results directory
         run: mkdir -p apps/builder/test-results
 
-      # Generate test report for better CI visibility
       - name: Generate test report
         if: success() || failure()
         run: pnpm --filter @openzeppelin/ui-builder-app test:report
 
-      # Upload test results as artifacts
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -22,32 +26,16 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check if app creds exist (base repo only)
-        id: has-app
-        run: |
-          present=true
-          if [ "${{ github.event.pull_request.head.repo.fork || false }}" = "true" ]; then present=false; fi
-          if [ -z "${{ vars.GH_APP_ID }}" ] || [ -z "${{ secrets.GH_APP_PRIVATE_KEY }}" ]; then present=false; fi
-          echo "present=$present" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/create-github-app-token@af35edadc00be37caa72ed9f3e6d5f7801bfdf09 # v1.11.7
-        id: gh-app-token
-        if: steps.has-app.outputs.present == 'true'
+      - name: Resolve authentication token
+        id: auth
+        uses: ./.github/actions/auth-token
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
-      - name: Select token
-        id: auth
-        run: |
-          if [ "${{ steps.has-app.outputs.present }}" = "true" ]; then
-            echo "token=${{ steps.gh-app-token.outputs.token }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "token=${{ github.token }}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+          is-fork: ${{ github.event.pull_request.head.repo.fork || false }}
 
       - name: Prepare pre-requisites
         uses: ./.github/actions/prepare
@@ -55,8 +43,10 @@ jobs:
           token: ${{ steps.auth.outputs.token }}
 
       - name: Configure npm authentication for npm registry
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,15 +15,14 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  id-token: write
-  attestations: write
-  actions: write
+  contents: read
 
 jobs:
   provenance:
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
     uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       run-scripts: 'install-pnpm, install-deps, build, test'
@@ -33,6 +32,12 @@ jobs:
   release:
     needs: [provenance]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+      attestations: write
+      actions: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -55,6 +60,7 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           token: ${{ steps.gh-app-token.outputs.token }}
+          fetch-depth: '0'
 
       - name: Verify dependencies
         run: pnpm audit
@@ -69,7 +75,7 @@ jobs:
           echo "path=${temp_dir}" >>"${GITHUB_OUTPUT}"
 
       - name: Upload tarball artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ github.ref_name }}
           path: ${{ needs.provenance.outputs.package-name }}
@@ -82,17 +88,20 @@ jobs:
           sha256: ${{ needs.provenance.outputs.package-download-sha256 }}
 
       - name: Download provenance
-        uses: slsa-framework/slsa-github-generator/actions/nodejs/secure-attestations-download@3bcecb4ade4f265cff30488059a9dca39e26b360 # v1.6.0
+        uses: slsa-framework/slsa-github-generator/actions/nodejs/secure-attestations-download@3bcecb4ade4f265cff30488059a9dca39e26b360 # main
         with:
           name: ${{ needs.provenance.outputs.provenance-download-name }}
           path: '${{ steps.temp-dir.outputs.path }}'
           sha256: ${{ needs.provenance.outputs.provenance-download-sha256 }}
 
       - name: Unpack the zipped artifact
+        env:
+          PACKAGE_NAME: ${{ needs.provenance.outputs.package-name }}
+          TEMP_DIR: ${{ steps.temp-dir.outputs.path }}
         run: |
           set -euo pipefail
-          cd "${{ steps.temp-dir.outputs.path }}"
-          tar -xzvf "${{ needs.provenance.outputs.package-name }}" -C $GITHUB_WORKSPACE --strip-components=1
+          cd "$TEMP_DIR"
+          tar -xzvf "$PACKAGE_NAME" -C "$GITHUB_WORKSPACE" --strip-components=1
           cd "$GITHUB_WORKSPACE"
           pnpm run install-deps
 
@@ -130,10 +139,10 @@ jobs:
         id: extract_version
         run: |
           version=$(jq -r '.version' package.json)
-          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@d94f46e13c6c62f59525ac9a1e147a99dc0b9bf5
+        uses: anchore/sbom-action@28d71544de8eaf1b958d335707167c5f783590ad # v0.22.2
         with:
           artifact-name: sbom-${{ github.event.repository.name }}-${{ steps.extract_version.outputs.version }}.spdx.json
           output-file: /${{ steps.temp-dir.outputs.path }}/sbom-${{ github.event.repository.name }}-${{ steps.extract_version.outputs.version }}.spdx.json
@@ -141,15 +150,15 @@ jobs:
           upload-release-assets: false
 
       - name: Download Artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
 
       - name: Upload attestations SLSA
-        uses: actions/attest-build-provenance@5e9cb68e95676991667494a6a4e59b8a2f13e1d0
+        uses: actions/attest-build-provenance@5e9cb68e95676991667494a6a4e59b8a2f13e1d0 # v1.3.3
         with:
           subject-path: ${{ needs.provenance.outputs.provenance-download-name }}
           subject-name: ${{ github.event.repository.name }}-${{ steps.extract_version.outputs.version }}
 
       - name: Upload attestations SBOM
-        uses: actions/attest-build-provenance@5e9cb68e95676991667494a6a4e59b8a2f13e1d0
+        uses: actions/attest-build-provenance@5e9cb68e95676991667494a6a4e59b8a2f13e1d0 # v1.3.3
         with:
           subject-path: /${{ steps.temp-dir.outputs.path }}/sbom-${{ github.event.repository.name }}-${{ steps.extract_version.outputs.version }}.spdx.json

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,20 +25,17 @@ jobs:
       security-events: write
       # Needed to publish results and get a badge (see publish_results below).
       id-token: write
-      # comment the permissions below if installing in a public repository.
-      # contents: read
-      # actions: read
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49  # v2.12.2
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.5.4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
       - name: Run analysis
-        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde  # v2.4.2
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
         with:
           results_file: results.sarif
           results_format: sarif
@@ -46,12 +43,12 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
       - name: Upload SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d  # v3.29.5
+        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
         with:
           sarif_file: results.sarif

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -15,30 +15,34 @@ jobs:
   update-deps:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
 
-      - uses: actions/create-github-app-token@af35edadc00be37caa72ed9f3e6d5f7801bfdf09 # v1.11.7
-        id: gh-app-token
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Resolve authentication token
+        id: auth
+        uses: ./.github/actions/auth-token
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
-      - name: Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
       - name: Prepare pre-requisites
         uses: ./.github/actions/prepare
         with:
-          token: ${{ steps.gh-app-token.outputs.token }}
+          token: ${{ steps.auth.outputs.token }}
 
       - name: Configure npm authentication for npm registry
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 
       - name: Install dependencies
         run: pnpm install
@@ -46,14 +50,14 @@ jobs:
       - name: Check for outdated dependencies
         id: outdated
         run: |
-          echo "OUTDATED_DEPS=$(pnpm outdated --format json)" >> $GITHUB_ENV
+          echo "OUTDATED_DEPS=$(pnpm outdated --format json)" >> "$GITHUB_ENV"
         continue-on-error: true
 
       - name: Create PR for dependency updates
         if: success()
         uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5.0.3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.auth.outputs.token }}
           commit-message: 'chore(deps): update dependencies'
           title: 'chore(deps): update dependencies'
           body: |

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -28,40 +28,28 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check if app creds exist (base repo only)
-        id: has-app
-        run: |
-          present=true
-          if [ "${{ github.event.pull_request.head.repo.fork || false }}" = "true" ]; then present=false; fi
-          if [ -z "${{ vars.GH_APP_ID }}" ] || [ -z "${{ secrets.GH_APP_PRIVATE_KEY }}" ]; then present=false; fi
-          echo "present=$present" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/create-github-app-token@af35edadc00be37caa72ed9f3e6d5f7801bfdf09 # v1.11.7
-        id: gh-app-token
-        if: steps.has-app.outputs.present == 'true'
+      - name: Resolve authentication token
+        id: auth
+        uses: ./.github/actions/auth-token
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
-      - name: Select token
-        id: auth
-        run: |
-          if [ "${{ steps.has-app.outputs.present }}" = "true" ]; then
-            echo "token=${{ steps.gh-app-token.outputs.token }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "token=${{ github.token }}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          token: ${{ steps.auth.outputs.token }}
-          fetch-depth: 0
+          is-fork: ${{ github.event.pull_request.head.repo.fork || false }}
 
       - name: Prepare pre-requisites
         uses: ./.github/actions/prepare
         with:
           token: ${{ steps.auth.outputs.token }}
+          fetch-depth: '0'
+
+      - name: Configure npm authentication for npm registry
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 
       - name: Install dependencies
         run: pnpm install
@@ -77,9 +65,9 @@ jobs:
         run: |
           # Check if either versions.ts or snapshot files have changed
           if git diff --exit-code apps/builder/src/export/versions.ts apps/builder/src/export/__tests__/__snapshots__/; then
-            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "changed=false" >> "$GITHUB_OUTPUT"
           else
-            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Commit and push changes
@@ -87,11 +75,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.auth.outputs.token }}
           HUSKY: 0 # Disable husky hooks for automated commits
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           # Checkout the proper branch (handle both PR and push events)
-          BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
           git checkout "$BRANCH_NAME"
           # Add both versions.ts and any updated snapshot files
           git add apps/builder/src/export/versions.ts apps/builder/src/export/__tests__/__snapshots__/


### PR DESCRIPTION
## Summary
- Extract repeated token-resolution logic into a reusable `auth-token` composite action
- Fix expression injection vulnerabilities by passing secrets/contexts through env vars instead of inline `${{ }}` in `run:` blocks
- Add concurrency groups, bump pinned action versions, apply least-privilege permissions, and quote shell variables

## Test plan
- [ ] Verify CI workflows pass on this PR (lint, test, coverage, export-testing)
- [ ] Confirm auth-token composite action resolves tokens correctly for base-repo and fork PRs
- [ ] Validate that concurrency groups cancel redundant runs as expected