### PR TITLE
fix(builder): align sidebar selection with design tokens

### DIFF
--- a/apps/builder/src/components/Sidebar/AppSidebar/MainActions.tsx
+++ b/apps/builder/src/components/Sidebar/AppSidebar/MainActions.tsx
@@ -9,7 +9,6 @@ import {
 import { useState } from 'react';
 
 import { SidebarButton } from '@openzeppelin/ui-components';
-import { cn } from '@openzeppelin/ui-utils';
 
 import { useContractUIStorage } from '../../../contexts/useContractUIStorage';
 import { useBuilderAnalytics } from '../../../hooks/useBuilderAnalytics';
@@ -55,16 +54,14 @@ export default function MainActions({
   const [showAddressBook, setShowAddressBook] = useState(false);
 
   return (
-    <div className="flex flex-col w-full">
-      <div className={cn(isInNewUIMode && 'bg-neutral-100 rounded-lg')}>
-        <SidebarButton
-          icon={<SquarePen className="size-4" />}
-          onClick={onCreateNew}
-          isSelected={isInNewUIMode}
-        >
-          New Contract UI
-        </SidebarButton>
-      </div>
+    <div className="flex w-full flex-col">
+      <SidebarButton
+        icon={<SquarePen className="size-4" />}
+        onClick={onCreateNew}
+        isSelected={isInNewUIMode}
+      >
+        New Contract UI
+      </SidebarButton>
 
       <SidebarButton icon={<LayoutPanelTop className="size-4" />} badge="Coming Soon" disabled>
         Templates

--- a/apps/builder/src/components/Sidebar/ContractUIs/ContractUIItem.tsx
+++ b/apps/builder/src/components/Sidebar/ContractUIs/ContractUIItem.tsx
@@ -84,28 +84,20 @@ export default function ContractUIItem({
       <div
         onClick={onLoad}
         className={cn(
-          'group relative flex items-center justify-between h-11 px-3 py-2.5 cursor-pointer w-[225px] rounded-lg transition-all duration-300 ease-in-out',
+          'group relative flex h-11 w-[225px] cursor-pointer items-center justify-between rounded-lg px-3 py-2.5 transition-all duration-300 ease-in-out',
           // Background animation for operations in progress (with artificial delay)
-          showLoadingAnimation && 'bg-muted animate-pulse [animation-duration:1200ms] opacity-30',
-          // Selected state
-          isCurrentlyLoaded
-            ? // TODO: Replace with OpenZeppelin theme colors for selected state
-              // Should use semantic token like 'bg-sidebar-item-selected'
-              'bg-neutral-100'
-            : 'hover:before:content-[""] hover:before:absolute hover:before:inset-x-0 hover:before:top-1 hover:before:bottom-1 hover:before:bg-muted/80 hover:before:rounded-lg hover:before:-z-10'
+          showLoadingAnimation && 'animate-pulse bg-muted opacity-30 [animation-duration:1200ms]',
+          // Selected / hover — align with `SidebarButton` (`text-selected bg-selected/10`)
+          !showLoadingAnimation &&
+            (isCurrentlyLoaded
+              ? 'bg-selected/10 text-selected'
+              : 'text-muted-foreground hover:bg-muted/50')
         )}
       >
         {/* Content */}
         <div className="min-w-0 flex-1 flex items-center gap-2">
           <div className="min-w-0 flex-1">
-            <h3
-              className={cn(
-                'font-semibold text-sm truncate',
-                // TODO: Replace hard-coded text colors with OpenZeppelin theme
-                // Should use semantic tokens like 'text-sidebar-item-selected' and 'text-sidebar-item'
-                isCurrentlyLoaded ? 'text-[#111928]' : 'text-gray-600'
-              )}
-            >
+            <h3 className="truncate text-sm font-semibold">
               {animatedTitle}
               {isTitleAnimating && <span className="animate-pulse text-current">|</span>}
             </h3>

--- a/apps/builder/src/export/__tests__/__snapshots__/ExportSnapshotTests.test.ts.snap
+++ b/apps/builder/src/export/__tests__/__snapshots__/ExportSnapshotTests.test.ts.snap
@@ -342,7 +342,7 @@ exports[`Export Snapshot Tests > evm Export Snapshots > should match snapshot fo
 {
   "dependencies": {
     "@openzeppelin/adapter-evm": "^2.0.1",
-    "@openzeppelin/ui-components": "^2.0.1",
+    "@openzeppelin/ui-components": "^2.2.0",
     "@openzeppelin/ui-react": "^2.0.1",
     "@openzeppelin/ui-renderer": "^2.0.0",
     "@openzeppelin/ui-types": "^2.0.0",
@@ -709,7 +709,7 @@ exports[`Export Snapshot Tests > polkadot Export Snapshots > should match snapsh
 {
   "dependencies": {
     "@openzeppelin/adapter-polkadot": "^2.0.0",
-    "@openzeppelin/ui-components": "^2.0.1",
+    "@openzeppelin/ui-components": "^2.2.0",
     "@openzeppelin/ui-react": "^2.0.1",
     "@openzeppelin/ui-renderer": "^2.0.0",
     "@openzeppelin/ui-types": "^2.0.0",

--- a/apps/builder/src/export/versions.ts
+++ b/apps/builder/src/export/versions.ts
@@ -15,7 +15,7 @@ export const packageVersions = {
   '@openzeppelin/ui-renderer': '2.0.0',
   '@openzeppelin/ui-storage': '1.2.1',
   '@openzeppelin/ui-types': '2.0.0',
-  '@openzeppelin/ui-components': '2.0.1',
+  '@openzeppelin/ui-components': '2.2.0',
   '@openzeppelin/ui-utils': '2.0.0',
   '@openzeppelin/ui-styles': '1.1.0',
 };


### PR DESCRIPTION
## Summary
Aligns sidebar list selection with `SidebarButton` and removes duplicate backgrounds.

- **ContractUIItem** — Loaded contract uses `bg-selected/10` and `text-selected` instead of `bg-neutral-100` / hard-coded hex; default row uses `text-muted-foreground` and `hover:bg-muted/50`.
- **MainActions** — Removes the extra wrapper `bg-neutral-100` around "New Contract UI" so it no longer stacks on top of `SidebarButton`’s selected styles (`bg-selected/10`).

## Also
Pre-push hook synced `apps/builder/src/export/versions.ts` (`@openzeppelin/ui-components` `2.2.0`) and updated export snapshot tests.

## Test plan
- [ ] Sidebar: select "New Contract UI" — single selected tint, no split background
- [ ] Sidebar: select a saved contract — row matches other `SidebarButton` selected state
- [ ] `pnpm --filter @openzeppelin/ui-builder-app test` (export snapshots included in commit)