### PR TITLE
fix(export): sync export versions and stop the pin test from drifting

### DIFF
--- a/apps/builder/src/export/__tests__/EnsExportPins.verification.test.ts
+++ b/apps/builder/src/export/__tests__/EnsExportPins.verification.test.ts
@@ -5,11 +5,13 @@ import { describe, expect, it } from 'vitest';
 
 import { getNetworksByEcosystem } from '../../core/ecosystemManager';
 import { AppExportSystem } from '../AppExportSystem';
+import { EXTERNAL_DEPENDENCY_FLOORS } from '../dependencyFloors';
 import { createMinimalContractSchema, createMinimalFormConfig } from '../utils/testConfig';
 import { extractFilesFromZip } from '../utils/zipInspector';
+import { packageVersions } from '../versions';
 
 describe('ENS export dependency pins (production)', () => {
-  it('pins ui-types ^3.3.0, viem ^2.35.0, adapter-evm ^2.3.0 and ships .npmrc + vite interop', async () => {
+  it('pins the declared package versions and ships .npmrc + vite interop', async () => {
     const networks = await getNetworksByEcosystem('evm');
     const networkConfig = networks.find((n) => n.id === 'ethereum-mainnet') ?? networks[0];
     expect(networkConfig).toBeDefined();
@@ -30,12 +32,22 @@ describe('ENS export dependency pins (production)', () => {
     const packageJson = JSON.parse(files['package.json']);
     const deps = packageJson.dependencies as Record<string, string>;
 
-    expect(deps['@openzeppelin/ui-types']).toBe('^3.3.0');
-    expect(deps['viem']).toBe('^2.35.0');
-    expect(deps['@openzeppelin/adapter-evm']).toBe('^2.3.0');
-    expect(deps['@openzeppelin/ui-components']).toBe('^3.8.1');
-    expect(deps['@openzeppelin/ui-renderer']).toBe('^3.4.0');
-    expect(deps['@openzeppelin/ui-react']).toBe('^3.3.0');
+    // Assert against the declared sources of truth rather than duplicating the
+    // version literals here. `packageVersions` is maintained by
+    // `pnpm run update-export-versions`, so hardcoding them made every release
+    // fail this test and, in turn, block that script's own snapshot refresh.
+    for (const name of [
+      '@openzeppelin/ui-types',
+      '@openzeppelin/adapter-evm',
+      '@openzeppelin/ui-components',
+      '@openzeppelin/ui-renderer',
+      '@openzeppelin/ui-react',
+    ] as const) {
+      expect(deps[name], name).toBe(`^${packageVersions[name]}`);
+    }
+
+    // viem is a floor rather than a published-version pin.
+    expect(deps['viem']).toBe(EXTERNAL_DEPENDENCY_FLOORS.viem);
 
     expect(files['.npmrc']).toBeDefined();
     expect(files['.npmrc']).toContain('public-hoist-pattern[]=eventemitter3');

--- a/apps/builder/src/export/__tests__/__snapshots__/ExportSnapshotTests.test.ts.snap
+++ b/apps/builder/src/export/__tests__/__snapshots__/ExportSnapshotTests.test.ts.snap
@@ -341,11 +341,11 @@ export default function GeneratedForm({ adapter, isWalletConnected }: GeneratedF
 exports[`Export Snapshot Tests > evm Export Snapshots > should match snapshot for package.json structure > package-json-evm 1`] = `
 {
   "dependencies": {
-    "@openzeppelin/adapter-evm": "^2.3.0",
+    "@openzeppelin/adapter-evm": "^2.7.0",
     "@openzeppelin/ui-components": "^3.8.1",
     "@openzeppelin/ui-react": "^3.3.0",
     "@openzeppelin/ui-renderer": "^3.4.0",
-    "@openzeppelin/ui-types": "^3.3.0",
+    "@openzeppelin/ui-types": "^3.5.0",
     "@openzeppelin/ui-utils": "^3.3.0",
     "@tanstack/react-query": "^5.0.0",
     "@wagmi/core": "^2.20.3",
@@ -712,7 +712,7 @@ exports[`Export Snapshot Tests > polkadot Export Snapshots > should match snapsh
     "@openzeppelin/ui-components": "^3.8.1",
     "@openzeppelin/ui-react": "^3.3.0",
     "@openzeppelin/ui-renderer": "^3.4.0",
-    "@openzeppelin/ui-types": "^3.3.0",
+    "@openzeppelin/ui-types": "^3.5.0",
     "@openzeppelin/ui-utils": "^3.3.0",
     "@tanstack/react-query": "^5.0.0",
     "@wagmi/core": "^2.20.3",

--- a/apps/builder/src/export/versions.ts
+++ b/apps/builder/src/export/versions.ts
@@ -6,7 +6,7 @@
  */
 
 export const packageVersions = {
-  '@openzeppelin/adapter-evm': '2.3.0',
+  '@openzeppelin/adapter-evm': '2.7.0',
   '@openzeppelin/adapter-midnight': '2.2.0',
   '@openzeppelin/adapter-polkadot': '2.2.0',
   '@openzeppelin/adapter-solana': '2.2.0',
@@ -14,7 +14,7 @@ export const packageVersions = {
   '@openzeppelin/ui-react': '3.3.0',
   '@openzeppelin/ui-renderer': '3.4.0',
   '@openzeppelin/ui-storage': '1.2.3',
-  '@openzeppelin/ui-types': '3.3.0',
+  '@openzeppelin/ui-types': '3.5.0',
   '@openzeppelin/ui-components': '3.8.1',
   '@openzeppelin/ui-utils': '3.3.0',
   '@openzeppelin/ui-styles': '1.1.0',


### PR DESCRIPTION
## Problem

`check-versions` has been failing on **every** PR in this repo, and `pre-push` aborts for anyone working here:

```
AssertionError: expected '^3.5.0' to be '^3.3.0'
```

I hit it on #410 and #411 and initially set it aside as pre-existing (reproduced on a clean `main`, [details here](https://github.com/OpenZeppelin/ui-builder/pull/410#issuecomment-5358123555)). It gates merging, so it needs its own fix.

There are two independent causes.

### 1. `versions.ts` was stale

`@openzeppelin/ui-types@3.5.0` and `@openzeppelin/adapter-evm@2.7.0` are published, while `main` still pinned `3.3.0` and `2.3.0`. Fixed by running the repo's own `pnpm run update-export-versions`, which also refreshes the export snapshots.

### 2. The pin test duplicated those versions — a deadlock

`EnsExportPins.verification.test.ts` hardcoded six version literals that `versions.ts` already declares. That double-maintenance is what turned a routine release into a blocked repo:

1. A dependency is published → `versions.ts` is now stale.
2. The sync script rewrites `versions.ts`.
3. The test still asserts the old literals, so it fails.
4. The script refreshes snapshots **by running that same vitest suite** — so the failing assertion aborts the script's own snapshot step.

**The drift could not be fixed by running the tool designed to fix it.** That's why it sat broken.

The test now asserts against the declared sources of truth — `packageVersions` for published packages, `EXTERNAL_DEPENDENCY_FLOORS` for the `viem` floor:

```ts
for (const name of ['@openzeppelin/ui-types', '@openzeppelin/adapter-evm', ...] as const) {
  expect(deps[name], name).toBe(`^${packageVersions[name]}`);
}
expect(deps['viem']).toBe(EXTERNAL_DEPENDENCY_FLOORS.viem);
```

It still verifies the real invariant — an exported app pins exactly what this repo declares — but no longer needs a manual edit on every release, so this cannot recur.

## Verification

- `pnpm run update-export-versions` exits **0** and leaves the tree clean (the condition the CI job actually checks)
- **46 test files pass**, 0 failures
- typecheck, lint, `format:check` clean
- production build succeeds

## Scope

This does change exported apps' pins for `ui-types` and `adapter-evm` — that is the sync script's purpose. It is unrelated to the Trezor (#410) and WalletConnect (#411) work and lands separately so it unblocks both. **Merge this first**, then rebase those two.
