### PR TITLE
fix(export): sync export versions with the published adapter and UI releases

### DIFF
--- a/apps/builder/src/export/__tests__/__snapshots__/ExportSnapshotTests.test.ts.snap
+++ b/apps/builder/src/export/__tests__/__snapshots__/ExportSnapshotTests.test.ts.snap
@@ -341,12 +341,12 @@ export default function GeneratedForm({ adapter, isWalletConnected }: GeneratedF
 exports[`Export Snapshot Tests > evm Export Snapshots > should match snapshot for package.json structure > package-json-evm 1`] = `
 {
   "dependencies": {
-    "@openzeppelin/adapter-evm": "^2.7.0",
-    "@openzeppelin/ui-components": "^3.8.1",
-    "@openzeppelin/ui-react": "^3.3.0",
-    "@openzeppelin/ui-renderer": "^3.4.0",
-    "@openzeppelin/ui-types": "^3.5.0",
-    "@openzeppelin/ui-utils": "^3.3.0",
+    "@openzeppelin/adapter-evm": "^3.0.0",
+    "@openzeppelin/ui-components": "^3.8.2",
+    "@openzeppelin/ui-react": "^3.3.1",
+    "@openzeppelin/ui-renderer": "^3.4.1",
+    "@openzeppelin/ui-types": "^3.5.1",
+    "@openzeppelin/ui-utils": "^4.0.0",
     "@tanstack/react-query": "^5.0.0",
     "@wagmi/core": "^2.20.3",
     "react": "^19.2.1",
@@ -708,12 +708,12 @@ export default function GeneratedForm({ adapter, isWalletConnected }: GeneratedF
 exports[`Export Snapshot Tests > polkadot Export Snapshots > should match snapshot for package.json structure > package-json-polkadot 1`] = `
 {
   "dependencies": {
-    "@openzeppelin/adapter-polkadot": "^2.2.0",
-    "@openzeppelin/ui-components": "^3.8.1",
-    "@openzeppelin/ui-react": "^3.3.0",
-    "@openzeppelin/ui-renderer": "^3.4.0",
-    "@openzeppelin/ui-types": "^3.5.0",
-    "@openzeppelin/ui-utils": "^3.3.0",
+    "@openzeppelin/adapter-polkadot": "^3.0.0",
+    "@openzeppelin/ui-components": "^3.8.2",
+    "@openzeppelin/ui-react": "^3.3.1",
+    "@openzeppelin/ui-renderer": "^3.4.1",
+    "@openzeppelin/ui-types": "^3.5.1",
+    "@openzeppelin/ui-utils": "^4.0.0",
     "@tanstack/react-query": "^5.0.0",
     "@wagmi/core": "^2.20.3",
     "react": "^19.2.1",

--- a/apps/builder/src/export/versions.ts
+++ b/apps/builder/src/export/versions.ts
@@ -6,16 +6,16 @@
  */
 
 export const packageVersions = {
-  '@openzeppelin/adapter-evm': '2.7.0',
+  '@openzeppelin/adapter-evm': '3.0.0',
   '@openzeppelin/adapter-midnight': '2.2.0',
-  '@openzeppelin/adapter-polkadot': '2.2.0',
+  '@openzeppelin/adapter-polkadot': '3.0.0',
   '@openzeppelin/adapter-solana': '2.2.0',
-  '@openzeppelin/adapter-stellar': '2.2.0',
-  '@openzeppelin/ui-react': '3.3.0',
-  '@openzeppelin/ui-renderer': '3.4.0',
-  '@openzeppelin/ui-storage': '1.2.3',
-  '@openzeppelin/ui-types': '3.5.0',
-  '@openzeppelin/ui-components': '3.8.1',
-  '@openzeppelin/ui-utils': '3.3.0',
+  '@openzeppelin/adapter-stellar': '3.0.0',
+  '@openzeppelin/ui-react': '3.3.1',
+  '@openzeppelin/ui-renderer': '3.4.1',
+  '@openzeppelin/ui-storage': '1.2.4',
+  '@openzeppelin/ui-types': '3.5.1',
+  '@openzeppelin/ui-components': '3.8.2',
+  '@openzeppelin/ui-utils': '4.0.0',
   '@openzeppelin/ui-styles': '1.1.0',
 };


### PR DESCRIPTION
## Problem

`check-versions` is failing on every PR again (seen on #413). This is the maintenance the script exists for, not a new defect:

- `@openzeppelin/adapter-evm`, `adapter-polkadot`, `adapter-stellar` published **3.0.0**
- the openzeppelin-ui packages published a round — `ui-utils` **4.0.0**, `ui-types` 3.5.1, `ui-components` 3.8.2, `ui-react` 3.3.1, `ui-renderer` 3.4.1, `ui-storage` 1.2.4

so `versions.ts` went stale and the job's "Check for changes" step fails:

```
❌ Error: apps/builder/src/export/versions.ts is out of sync with resolved npm versions
```

## Fix

Ran `pnpm run update-export-versions`. It updated `versions.ts` and refreshed two export snapshots.

Worth noting the deadlock from last time **did not recur**: since #412 the pin test derives its expectations from `packageVersions` instead of duplicating the literals, so the sync script's own snapshot refresh no longer trips over a contradictory assertion. Nothing needed hand-editing.

## Verification

- `pnpm run update-export-versions` exits 0 and leaves `versions.ts` stable (the condition the CI job checks)
- **46 test files / 322 tests pass**
- production build succeeds; lint and `format:check` clean

## Two things for reviewers

**1. This raises exported apps to the adapter 3.x line while this repo's own `devDependencies` still pin `^2.x`.** So generated apps get adapter 3.x while the builder previews with 2.x — across a major boundary. That is what the follow-up adapter bump wave is for; syncing here is what unblocks CI now. Flagging it rather than folding a breaking dependency upgrade into a CI unblock.

**2. There is a flaky test unrelated to this change.** `useContractForm.reset-guard.test.tsx` intermittently throws `EnvironmentTeardownError: Cannot load '/src/export/assemblers/addCoreTemplateFiles.ts' … after the environment was torn down`. All 322 tests still pass, but the unhandled error makes vitest exit 1, which fails `check-versions` on its own. It reproduces locally, so it is not CI-specific — that is what the first failure on #413 actually was, before this drift surfaced underneath it. Worth fixing separately: it will keep causing spurious release/CI failures.
