### PR TITLE
fix(builder): stop a barrel import dragging the export system into a hook

### DIFF
--- a/apps/builder/src/components/UIBuilder/StepContractDefinition/hooks/useContractForm.ts
+++ b/apps/builder/src/components/UIBuilder/StepContractDefinition/hooks/useContractForm.ts
@@ -5,8 +5,8 @@ import type { FormValues } from '@openzeppelin/ui-types';
 
 import type { BuilderRuntime } from '@/core/runtimeAdapter';
 
-import { useDebounce } from '../../hooks';
 import { uiBuilderStore } from '../../hooks/uiBuilderStore';
+import { useDebounce } from '../../hooks/useDebounce';
 
 interface UseContractFormProps {
   runtime: BuilderRuntime | null;


### PR DESCRIPTION
## Problem

CI and local runs intermittently fail with:

```
EnvironmentTeardownError: Cannot load '/src/export/assemblers/addCoreTemplateFiles.ts'
imported from .../export/assemblers/index.ts after the environment was torn down
```

Every test still passes, but the unhandled error makes vitest exit 1. That is enough to fail `check-versions`, because `update-export-versions` refreshes snapshots by running that same suite — so the flake blocks unrelated PRs. It is **not** CI-specific; it reproduced locally roughly every other run.

## Cause

`useContractForm` imported `useDebounce` from the `../../hooks` **barrel**:

```ts
import { useDebounce } from '../../hooks';
```

That barrel re-exports `useUIBuilderState` and `useCompleteStepState`, which pull in `AppExportSystem` and the whole `export/assemblers` graph:

```
useContractForm
  └─ ../../hooks (barrel)
       └─ useUIBuilderState → useCompleteStepState → export/index
            └─ AppExportSystem → export/assemblers/index → addCoreTemplateFiles
```

So a hook needing one small debounce helper transitively loaded the entire export subsystem. `useContractForm.reset-guard.test.tsx` finishes quickly, and the tail of that lazily resolved graph landed *after* vitest tore the environment down.

## Fix

Import `useDebounce` from its own module rather than the barrel. The export system leaves this hook's dependency graph entirely — one line, no behaviour change.

## Verification

Stability was the whole point, so it was measured rather than assumed:

| Check | Result |
|---|---|
| Previously flaky test, 5 consecutive runs | exit 0, **0 teardown errors** each |
| `pnpm run update-export-versions`, 3 consecutive runs | exit 0 each (previously failed ~every other run) |
| Full suite | 46 files / 322 tests pass |
| typecheck / lint / `format:check` | clean |

## Follow-up worth considering

This is a symptom of barrel files coupling unrelated modules. Other hooks importing from `../../hooks` inherit the same graph; the flake surfaced here only because this test is fast enough to race teardown. Narrowing those imports (or splitting the barrel) would remove the class of problem rather than this instance.
