### PR TITLE
chore(ci): guard adapter peer versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Adapter peer version check
+        # The adapters enforce their @openzeppelin/ui-* minimums at runtime only, so a
+        # stale pin builds, typechecks and tests clean and then fails in the browser
+        # with the network runtime stuck failed. Nothing else in this job catches it.
+        run: pnpm exec oz-ui-dev check-peers --project "$PWD"
+
       - name: Build all packages
         run: pnpm -r build
         env:

--- a/apps/builder/src/export/__tests__/__snapshots__/ExportSnapshotTests.test.ts.snap
+++ b/apps/builder/src/export/__tests__/__snapshots__/ExportSnapshotTests.test.ts.snap
@@ -341,12 +341,12 @@ export default function GeneratedForm({ adapter, isWalletConnected }: GeneratedF
 exports[`Export Snapshot Tests > evm Export Snapshots > should match snapshot for package.json structure > package-json-evm 1`] = `
 {
   "dependencies": {
-    "@openzeppelin/adapter-evm": "^4.0.0",
-    "@openzeppelin/ui-components": "^3.8.2",
-    "@openzeppelin/ui-react": "^3.3.1",
-    "@openzeppelin/ui-renderer": "^3.4.1",
-    "@openzeppelin/ui-types": "^3.5.1",
-    "@openzeppelin/ui-utils": "^4.0.0",
+    "@openzeppelin/adapter-evm": "^5.0.0",
+    "@openzeppelin/ui-components": "^3.8.3",
+    "@openzeppelin/ui-react": "^3.3.2",
+    "@openzeppelin/ui-renderer": "^3.4.2",
+    "@openzeppelin/ui-types": "^3.5.2",
+    "@openzeppelin/ui-utils": "^4.0.1",
     "@tanstack/react-query": "^5.0.0",
     "@wagmi/core": "^2.20.3",
     "react": "^19.2.1",
@@ -708,12 +708,12 @@ export default function GeneratedForm({ adapter, isWalletConnected }: GeneratedF
 exports[`Export Snapshot Tests > polkadot Export Snapshots > should match snapshot for package.json structure > package-json-polkadot 1`] = `
 {
   "dependencies": {
-    "@openzeppelin/adapter-polkadot": "^3.0.0",
-    "@openzeppelin/ui-components": "^3.8.2",
-    "@openzeppelin/ui-react": "^3.3.1",
-    "@openzeppelin/ui-renderer": "^3.4.1",
-    "@openzeppelin/ui-types": "^3.5.1",
-    "@openzeppelin/ui-utils": "^4.0.0",
+    "@openzeppelin/adapter-polkadot": "^5.0.0",
+    "@openzeppelin/ui-components": "^3.8.3",
+    "@openzeppelin/ui-react": "^3.3.2",
+    "@openzeppelin/ui-renderer": "^3.4.2",
+    "@openzeppelin/ui-types": "^3.5.2",
+    "@openzeppelin/ui-utils": "^4.0.1",
     "@tanstack/react-query": "^5.0.0",
     "@wagmi/core": "^2.20.3",
     "react": "^19.2.1",

--- a/apps/builder/src/export/versions.ts
+++ b/apps/builder/src/export/versions.ts
@@ -6,16 +6,16 @@
  */
 
 export const packageVersions = {
-  '@openzeppelin/adapter-evm': '4.0.0',
-  '@openzeppelin/adapter-midnight': '4.0.0',
-  '@openzeppelin/adapter-polkadot': '3.0.0',
-  '@openzeppelin/adapter-solana': '4.0.0',
-  '@openzeppelin/adapter-stellar': '4.0.0',
-  '@openzeppelin/ui-react': '3.3.1',
-  '@openzeppelin/ui-renderer': '3.4.1',
-  '@openzeppelin/ui-storage': '1.2.4',
-  '@openzeppelin/ui-types': '3.5.1',
-  '@openzeppelin/ui-components': '3.8.2',
-  '@openzeppelin/ui-utils': '4.0.0',
-  '@openzeppelin/ui-styles': '1.1.0',
+  '@openzeppelin/adapter-evm': '5.0.0',
+  '@openzeppelin/adapter-midnight': '4.0.1',
+  '@openzeppelin/adapter-polkadot': '5.0.0',
+  '@openzeppelin/adapter-solana': '4.0.1',
+  '@openzeppelin/adapter-stellar': '4.0.1',
+  '@openzeppelin/ui-react': '3.3.2',
+  '@openzeppelin/ui-renderer': '3.4.2',
+  '@openzeppelin/ui-storage': '1.2.5',
+  '@openzeppelin/ui-types': '3.5.2',
+  '@openzeppelin/ui-components': '3.8.3',
+  '@openzeppelin/ui-utils': '4.0.1',
+  '@openzeppelin/ui-styles': '1.1.1',
 };

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@commitlint/cz-commitlint": "^19.8.1",
     "@ianvs/prettier-plugin-sort-imports": "4.5.1",
     "@openzeppelin/docs-utils": "^0.1.6",
-    "@openzeppelin/ui-dev-cli": "^1.2.0",
+    "@openzeppelin/ui-dev-cli": "^1.3.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "export-app": "node apps/builder/src/export/cli/export-app.cjs",
     "preinstall": "npx only-allow pnpm",
     "install-pnpm": "npm install -g pnpm",
-    "check-licenses": "node scripts/check-dependency-licenses.cjs"
+    "check-licenses": "node scripts/check-dependency-licenses.cjs",
+    "check-adapter-peers": "oz-ui-dev check-peers --project \"$PWD\""
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,cjs,mjs}": "pnpm fix-all"
@@ -65,7 +66,7 @@
     "@commitlint/cz-commitlint": "^19.8.1",
     "@ianvs/prettier-plugin-sort-imports": "4.5.1",
     "@openzeppelin/docs-utils": "^0.1.6",
-    "@openzeppelin/ui-dev-cli": "^0.6.1",
+    "@openzeppelin/ui-dev-cli": "^1.2.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^0.1.6
         version: 0.1.6
       '@openzeppelin/ui-dev-cli':
-        specifier: ^0.6.1
-        version: 0.6.1
+        specifier: ^1.3.0
+        version: 1.3.0
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -1551,9 +1551,9 @@ packages:
       react: ^19.0.0
       react-dom: ^19.0.0
 
-  '@openzeppelin/ui-dev-cli@0.6.1':
-    resolution: {integrity: sha512-W5hdgcHuKJSpBUXqL+5l6fE5CMK/6jFnl23saLG/IsmgC9XSdYetl+wkiNjOFoVNQqlvVao5TPyRRXJYxrkA0g==}
-    engines: {node: '>=20.19.0'}
+  '@openzeppelin/ui-dev-cli@1.3.0':
+    resolution: {integrity: sha512-Q1BldxQ7wE6g+oDZ19USnnPfQlx0G7pLlPBHLNCE05Co7qZRbiC3gPQqHfgC1wCPBtAgd6nB3G4/IjFylVN66g==}
+    engines: {node: '>=22.13.0'}
     hasBin: true
 
   '@openzeppelin/ui-react@3.3.1':
@@ -1578,9 +1578,9 @@ packages:
   '@openzeppelin/ui-styles@1.1.0':
     resolution: {integrity: sha512-PSGe8k1M3zymLuhs3pus6MlhTgpTj7XFMEICTdTQYPDno/u6XL9AZM6hXlsK5dVlZTVjvmu3//LZ/K+81/Wc+Q==}
 
-  '@openzeppelin/ui-tailwind-utils@0.1.1':
-    resolution: {integrity: sha512-RGsMf4SARvzHJr0VesNss8JVgRGvqEINcK/e2XFXJb6QvkmaPzOoJylJGrMn5IevI0JWsyAXzhSrGRLmlBKpbg==}
-    engines: {node: '>=20.19.0'}
+  '@openzeppelin/ui-tailwind-utils@1.0.1':
+    resolution: {integrity: sha512-AAM64QJ0ihj/DMBE0SLYLnkiVQx6NuDdgb7cewfWVU1ZqrmNvnrfLpDwTQ6NHqtIO7VO3y89SgVPYWBdJpyCBQ==}
+    engines: {node: '>=22.13.0'}
 
   '@openzeppelin/ui-types@3.5.1':
     resolution: {integrity: sha512-j1baU8ary/qYKqoEs1vjzUdabbPOCRafJIGYaoD87wkr+V7UT3T08KVEMpZldZo0PhbKV8BUR2y/T/13T0nFxQ==}
@@ -9767,10 +9767,10 @@ snapshots:
       - tailwindcss
       - typescript
 
-  '@openzeppelin/ui-dev-cli@0.6.1':
+  '@openzeppelin/ui-dev-cli@1.3.0':
     dependencies:
       '@clack/prompts': 0.10.1
-      '@openzeppelin/ui-tailwind-utils': 0.1.1
+      '@openzeppelin/ui-tailwind-utils': 1.0.1
       commander: 13.1.0
       picocolors: 1.1.1
 
@@ -9828,7 +9828,7 @@ snapshots:
 
   '@openzeppelin/ui-styles@1.1.0': {}
 
-  '@openzeppelin/ui-tailwind-utils@0.1.1': {}
+  '@openzeppelin/ui-tailwind-utils@1.0.1': {}
 
   '@openzeppelin/ui-types@3.5.1': {}
 


### PR DESCRIPTION
## Why

`@openzeppelin/adapter-*` packages declare peerDependencies on `@openzeppelin/ui-*` but enforce them **only at runtime**, inside `validatePeerVersions()`. A repo that bumps the adapters without moving its `ui-*` pins passes typecheck, tests, build and lint, then fails in the browser with the network runtime stuck failed.

This repo had **no** guard against that. Its pins are correct today, but nothing would catch the next adapter major that moves a peer floor — it would land in staging instead of CI.

## Changes

- new CI step "Adapter peer version check" running `oz-ui-dev check-peers --project "$PWD"`
- `check-adapter-peers` npm script for running it locally
- `@openzeppelin/ui-dev-cli` → `^1.3.0`, the first published line carrying the command
- `versions.ts` synced to the published registry versions (the pre-push hook enforces this and refuses the push otherwise)

## Why the shared command rather than a local script

role-manager and rwa-wizard each carried a copy of this script. Both hardcoded `node_modules/@openzeppelin` at the repo root — which is why a straight copy into this repo failed outright, since dependencies here install under `apps/builder`. The shared command reuses the CLI's `collectWorkspacePackageDirs`, expanding `pnpm-workspace.yaml` globs, so it scans the root **and** every workspace package. A third copy would also have been a third thing to drift; the existing two already had.

## Verification

- `pnpm exec oz-ui-dev check-peers` → passes, **15 adapter/peer pairs**, resolving under `apps/builder/node_modules` — the layout that broke the old script
- the npm script path gives the same result
- export snapshot tests pass after the `versions.ts` sync (9 tests)

## Merge order

Merge **after** #417 in this repo. Both touch `ui-dev-cli` and `versions.ts`; the `versions.ts` content is byte-identical between the two branches, so it merges cleanly, and the `ui-dev-cli` line is a one-line conflict at worst.
